### PR TITLE
feat(685): add AvCancelConfirmButtons

### DIFF
--- a/a11y/tests/interaction/buttons/AvCancelConfirmButtons.a11y.test.ts
+++ b/a11y/tests/interaction/buttons/AvCancelConfirmButtons.a11y.test.ts
@@ -1,0 +1,11 @@
+import { testStories } from '../../../utils'
+
+const component = 'AvCancelConfirmButtons'
+const title = 'Components/Interaction/Buttons/AvCancelConfirmButtons'
+const stories = [
+  'Default',
+  'CancelOnly',
+  'ConfirmOnly',
+]
+
+testStories(component, title, stories)

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -64,6 +64,7 @@ export default defineConfig({
               text: 'Buttons',
               items: [
                 { text: 'AvButton', link: '/components/interaction/buttons/AvButton/AvButton.md' },
+                { text: 'AvCancelConfirmButtons', link: '/components/interaction/buttons/AvCancelConfirmButtons/AvCancelConfirmButtons.md' },
                 { text: 'AvRichButton', link: '/components/interaction/buttons/AvRichButton/AvRichButton.md' },
               ]
             },

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -25,6 +25,7 @@
 
 ### Buttons
 - [AvButton](interaction/buttons/AvButton/AvButton.md)
+- [AvCancelConfirmButtons](interaction/buttons/AvCancelConfirmButtons/AvCancelConfirmButtons.md)
 - [AvRichButton](interaction/buttons/AvRichButton/AvRichButton.md)
 
 ### Files

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -16,6 +16,7 @@ declare module 'vue' {
     AvAutocompleteSelectedTags: typeof import('./components/interaction/selects/AvAutocomplete/AvAutocompleteSelectedTags.vue')['default']
     AvBadge: typeof import('./components/badges/AvBadge/AvBadge.vue')['default']
     AvButton: typeof import('./components/interaction/buttons/AvButton/AvButton.vue')['default']
+    AvCancelConfirmButtons: typeof import('./components/interaction/buttons/AvCancelConfirmButtons/AvCancelConfirmButtons.vue')['default']
     AvCard: typeof import('./components/cards/AvCard/AvCard.vue')['default']
     AvDrawer: typeof import('./components/overlay/drawers/AvDrawer/AvDrawer.vue')['default']
     AvFileUpload: typeof import('./components/interaction/files/AvFileUpload/AvFileUpload.vue')['default']

--- a/src/components/interaction/buttons/AvCancelConfirmButtons/AvCancelConfirmButtons.md
+++ b/src/components/interaction/buttons/AvCancelConfirmButtons/AvCancelConfirmButtons.md
@@ -1,0 +1,68 @@
+# Cancel and confirm buttons - `AvCancelConfirmButtons`
+
+## ✨ Introduction
+
+The `AvCancelConfirmButtons` is an interaction element with an interface enabling the user to perform a cancel and/or a confirm action.
+
+## 🏗️ Structure
+
+This component consist of two optional buttons :
+
+- A cancel button, displayed by passing the `cancelLabel` prop,
+- A confirm button, displayed by passing the `confirmLabel` prop,
+
+## 🏷️ Props
+
+| Name | Type | Default | Mandatory | Description |
+| --- | --- | --- | --- | --- |
+| `cancelLabel` | `string` | `undefined` | | Label and title (for accessibility) of the cancel button. |
+| `cancelIcon` | `string` | `'mdi:close-circle-outline'` | | Icon name of the cancel button. |
+| `confiirmLabel` | `string` | `undefined` | | Label and title (for accessibility) of the confirm button. |
+| `confirmIcon` | `string` | `'mdi:check-circle-outline'` | | Icon name of the confirm button. |
+| `isLoading` | `boolean` | `false` | | Indicates a loading status for the buttons. |
+
+## 🔊 Events
+
+| Name | Data (*payload*) | Description |
+| --- | --- | --- |
+| `'cancel'` | | Event emitted when the cancel button is clicked. |
+| `'confirm'` | | Event emitted when the confirm button is clicked. |
+
+## 🎨 Slots
+
+None.
+
+## 🚀 Storybook demos
+
+You can find examples of use and demo of the component on its dedicated [Storybook page](https://avenirs-esr.github.io/avenirs-dsav/storybook/?path=/docs/components-interaction-buttons-avcancelconfirmbuttons--docs).
+
+## 💡 Examples of use
+
+```vue
+<template>
+  <AvCancelConfirmButton
+    cancel-label="Close"
+    @cancel="closeModal"
+  />
+</template>
+```
+
+```vue
+<template>
+  <AvCancelConfirmButton
+    confirm-label="Confirm"
+    @confirm="saveData"
+  />
+</template>
+```
+
+```vue
+<template>
+  <AvCancelConfirmButton
+    cancel-label="Previous step"
+    confirm-label="Next step"
+    @cancel="goToPrevStep"
+    @confirm="goToNextStep"
+  />
+</template>
+```

--- a/src/components/interaction/buttons/AvCancelConfirmButtons/AvCancelConfirmButtons.stories.ts
+++ b/src/components/interaction/buttons/AvCancelConfirmButtons/AvCancelConfirmButtons.stories.ts
@@ -1,0 +1,75 @@
+import type { Meta, StoryFn } from '@storybook/vue3'
+import AvCancelConfirmButtons, { type AvCancelConfirmButtonsProps } from '@/components/interaction/buttons/AvCancelConfirmButtons/AvCancelConfirmButtons.vue'
+
+/**
+ * <h2 class="n2">✨ Introduction</h2>
+ *
+ * <p>
+ *   <span class="b2-regular">
+ *     The <code>AvCancelConfirmButtons</code> is an interaction element with an interface enabling the user
+ *     to perform a cancel and/or a confirm action.
+ *   </span>
+ * </p>
+ *
+ * <h2 class="n2">🏗️ Structure</h2>
+ *
+ * <p>
+ *   <span class="b2-regular">
+ *     This component consists of two optional buttons:
+ *   </span>
+ * </p>
+ *
+ * <ul>
+ *   <li>
+ *     <span class="b2-regular">
+ *       A <strong>cancel button</strong>, displayed by passing the <code>cancelLabel</code> prop.
+ *     </span>
+ *   </li>
+ *   <li>
+ *     <span class="b2-regular">
+ *       A <strong>confirm button</strong>, displayed by passing the <code>confirmLabel</code> prop.
+ *     </span>
+ *   </li>
+ * </ul>
+ */
+const meta: Meta<AvCancelConfirmButtonsProps> = {
+  title: 'Components/Interaction/Buttons/AvCancelConfirmButtons',
+  component: AvCancelConfirmButtons,
+  argTypes: {
+    cancelLabel: { control: 'text' },
+    cancelIcon: { control: 'text' },
+    confirmLabel: { control: 'text' },
+    confirmIcon: { control: 'text' },
+  },
+  args: {
+    cancelLabel: 'Cancel',
+    cancelIcon: undefined,
+    confirmLabel: 'Confirm',
+    confirmIcon: undefined,
+  },
+}
+
+export default meta
+
+const Template: StoryFn<AvCancelConfirmButtonsProps> = args => ({
+  components: { AvCancelConfirmButtons },
+  setup () {
+    return { args }
+  },
+  template: `<AvCancelConfirmButtons v-bind="args" />`,
+})
+
+export const Default = Template.bind({})
+Default.args = {}
+
+export const CancelOnly = Template.bind({})
+CancelOnly.args = {
+  cancelLabel: 'Cancel',
+  confirmLabel: undefined
+}
+
+export const ConfirmOnly = Template.bind({})
+ConfirmOnly.args = {
+  confirmLabel: 'Confirm',
+  cancelLabel: undefined
+}

--- a/src/components/interaction/buttons/AvCancelConfirmButtons/AvCancelConfirmButtons.stub.ts
+++ b/src/components/interaction/buttons/AvCancelConfirmButtons/AvCancelConfirmButtons.stub.ts
@@ -1,0 +1,9 @@
+export const AvCancelConfirmButtonsStub = {
+  name: 'AvCancelConfirmButtons',
+  props: ['cancelLabel', 'cancelIcon', 'confirmLabel', 'confirmIcon', 'isLoading'],
+  emits: ['cancel', 'confirm'],
+  template: `
+    <button class="cancel" @click="$emit(\'cancel\')">{{ cancelLabel }}</button>
+    <button class="confirm" @click="$emit(\'confirm\')">{{ confirmLabel }}</button>
+  `
+}

--- a/src/components/interaction/buttons/AvCancelConfirmButtons/AvCancelConfirmButtons.test.ts
+++ b/src/components/interaction/buttons/AvCancelConfirmButtons/AvCancelConfirmButtons.test.ts
@@ -1,0 +1,107 @@
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect } from 'vitest'
+import { AvButtonStub } from '@/components/interaction/buttons/AvButton/AvButton.stub'
+import AvCancelConfirmButtons from '@/components/interaction/buttons/AvCancelConfirmButtons/AvCancelConfirmButtons.vue'
+import { BddTest } from '@/tests/utils'
+
+BddTest().given('an AvCancelConfirmButtons component', () => {
+  let wrapper: VueWrapper<InstanceType<typeof AvCancelConfirmButtons>>
+
+  const stubs = { AvButton: AvButtonStub }
+
+  BddTest().and('no props are passed', () => {
+    beforeEach(() => {
+      wrapper = mount(AvCancelConfirmButtons, { global: { stubs } })
+    })
+
+    BddTest().when('the component is mounted', () => {
+      BddTest().then('it should not render anything', () => {
+        expect(wrapper.findAllComponents({ name: 'AvButton' })).toHaveLength(0)
+      })
+    })
+  })
+
+  BddTest().and('a cancel label is passed', () => {
+    beforeEach(() => {
+      wrapper = mount(AvCancelConfirmButtons, {
+        props: { cancelLabel: 'Cancel' },
+        global: { stubs }
+      })
+    })
+
+    BddTest().when('the component is mounted', () => {
+      BddTest().then('it should only render the cancel button', () => {
+        const buttons = wrapper.findAllComponents({ name: 'AvButton' })
+        expect(buttons).toHaveLength(1)
+        expect(buttons[0].text()).toContain('Cancel')
+      })
+
+      BddTest().and('the cancel button is clicked', () => {
+        BddTest().then('it should emit cancel', async () => {
+          const buttons = wrapper.findAllComponents({ name: 'AvButton' })
+          await buttons[0].trigger('click')
+          expect(wrapper.emitted('cancel')).toBeDefined()
+        })
+      })
+    })
+  })
+
+  BddTest().and('a confirm label is passed', () => {
+    beforeEach(() => {
+      wrapper = mount(AvCancelConfirmButtons, {
+        props: { confirmLabel: 'Confirm' },
+        global: { stubs }
+      })
+    })
+
+    BddTest().when('the component is mounted', () => {
+      BddTest().then('it should only render the confirm button', () => {
+        const buttons = wrapper.findAllComponents({ name: 'AvButton' })
+        expect(buttons).toHaveLength(1)
+        expect(buttons[0].text()).toContain('Confirm')
+      })
+
+      BddTest().and('the confirm button is clicked', () => {
+        BddTest().then('it should emit confirm', async () => {
+          const buttons = wrapper.findAllComponents({ name: 'AvButton' })
+          await buttons[0].trigger('click')
+          expect(wrapper.emitted('confirm')).toBeDefined()
+        })
+      })
+    })
+  })
+
+  BddTest().and('cancel and confirm labels are passed', () => {
+    beforeEach(() => {
+      wrapper = mount(AvCancelConfirmButtons, {
+        props: { cancelLabel: 'Cancel', confirmLabel: 'Confirm' },
+        global: { stubs }
+      })
+    })
+
+    BddTest().when('the component is mounted', () => {
+      BddTest().then('it should render the cancel and the confirm buttons', () => {
+        const buttons = wrapper.findAllComponents({ name: 'AvButton' })
+        expect(buttons).toHaveLength(2)
+        expect(buttons[0].text()).toContain('Cancel')
+        expect(buttons[1].text()).toContain('Confirm')
+      })
+
+      BddTest().and('the cancel button is clicked', () => {
+        BddTest().then('it should emit cancel', async () => {
+          const buttons = wrapper.findAllComponents({ name: 'AvButton' })
+          await buttons[0].trigger('click')
+          expect(wrapper.emitted('cancel')).toBeDefined()
+        })
+      })
+
+      BddTest().and('the confirm button is clicked', () => {
+        BddTest().then('it should emit confirm', async () => {
+          const buttons = wrapper.findAllComponents({ name: 'AvButton' })
+          await buttons[1].trigger('click')
+          expect(wrapper.emitted('confirm')).toBeDefined()
+        })
+      })
+    })
+  })
+})

--- a/src/components/interaction/buttons/AvCancelConfirmButtons/AvCancelConfirmButtons.vue
+++ b/src/components/interaction/buttons/AvCancelConfirmButtons/AvCancelConfirmButtons.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+import { AvButton } from '@/components/interaction'
+import { MDI_ICONS } from '@/tokens'
+
+/**
+ * AvCancelConfirmButtons component props.
+ */
+export interface AvCancelConfirmButtonsProps {
+  /**
+   * Label and title (for accessibility) of the cancel button.
+   */
+  cancelLabel?: string
+
+  /**
+   * Icon name of the cancel button.
+   * @default 'mdi:close-circle-outline'
+   */
+  cancelIcon?: string
+
+  /**
+   * Label and title (for accessibility) of the confirm button.
+   */
+  confirmLabel?: string
+
+  /**
+   * Icon name of the confirm button.
+   * @default 'mdi:check-circle-outline'
+   */
+  confirmIcon?: string
+
+  /**
+   * Adds a loading state on the buttons.
+   */
+  isLoading?: boolean
+}
+
+const {
+  cancelLabel,
+  cancelIcon = MDI_ICONS.CLOSE_CIRCLE_OUTLINE,
+  confirmLabel,
+  confirmIcon = MDI_ICONS.CLOSE_CIRCLE_OUTLINE,
+  isLoading
+} = defineProps<AvCancelConfirmButtonsProps>()
+
+/**
+ * Events emitted by the component.
+ *
+ * @event cancel - Event emitted when the cancel button is clicked.
+ * @event confirm - Event emitted when the confirm button is clicked.
+ */
+const emit = defineEmits<{
+  (e: 'cancel'): void
+  (e: 'confirm'): void
+}>()
+</script>
+
+<template>
+  <div class="av-cancel-confirm-buttons-container">
+    <AvButton
+      v-if="cancelLabel"
+      :icon="cancelIcon"
+      :label="cancelLabel"
+      :title="cancelLabel"
+      variant="OUTLINED"
+      :is-loading="isLoading"
+      size="sm"
+      @click="() => emit('cancel')"
+    />
+    <AvButton
+      v-if="confirmLabel"
+      :icon="confirmIcon"
+      :label="confirmLabel"
+      :title="confirmLabel"
+      variant="FLAT"
+      :is-loading="isLoading"
+      size="sm"
+      @click="() => emit('confirm')"
+    />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.av-cancel-confirm-buttons-container {
+  display: flex;
+  flex-direction: row;
+  gap: var(--spacing-sm);
+}
+</style>

--- a/src/components/interaction/buttons/index.ts
+++ b/src/components/interaction/buttons/index.ts
@@ -1,3 +1,4 @@
 export { AvButtonStub } from './AvButton/AvButton.stub'
 export { default as AvButton, type AvButtonProps } from './AvButton/AvButton.vue'
+export { default as AvCancelConfirmButtons } from './AvCancelConfirmButtons/AvCancelConfirmButtons.vue'
 export { default as AvRichButton } from './AvRichButton/AvRichButton.vue'

--- a/src/components/overlay/modals/AvModal/AvModal.md
+++ b/src/components/overlay/modals/AvModal/AvModal.md
@@ -26,13 +26,15 @@ It consists of the following elements:
 | `icon` | `string` | `undefined` | | Name of icon to be displayed in modal title. |
 | `size` | `'sm' \| 'md' \| 'lg' \| 'xl'` | `md` | | Size of modal. |
 | `closeButtonLabel` | `string` | | ✅ | Label and title (for accessibility) of close button. |
-| `closeButtonVariant` | `'DEFAULT' \| 'OUTLINED' \| undefined` | `'DEFAULT'` | | Variant of close button: without border (`DEFAULT`) or with border (`OUTLINED`). |
+| `confirmButtonLabel` | `string` | `undefined` | | Label and title (for accessibility) of confirm button. |
+| `confirmButtonIcon` | `string` | `mdi:check-circle-outline` | | Icon name of confirm button. |
 
 ## 🔊 Events
 
 | Name | Data (*payload*) | Description |
 | --- | --- | --- |
-| `‘close’` | `number` | Event emitted when modal is closed. |
+| `‘close’` | | Event emitted when modal is closed. |
+| `‘close’` | | Event emitted when confirm button is clicked. |
 
 ## 🎨 Slots
 

--- a/src/components/overlay/modals/AvModal/AvModal.test.ts
+++ b/src/components/overlay/modals/AvModal/AvModal.test.ts
@@ -20,6 +20,36 @@ BddTest().given('an AvModal', () => {
     closeButtonLabel: 'Close'
   }
 
+  const propsWithConfirm: AvModalProps = {
+    opened: true,
+    closeButtonLabel: 'Close',
+    confirmButtonLabel: 'Confirm'
+  }
+
+  BddTest().and('a confirm label is passed', () => {
+    BddTest().when('the modal is mounted', () => {
+      beforeEach(() => {
+        wrapper = mount(AvModal, {
+          props: propsWithConfirm,
+          slots: {
+            default: '<div class="content">Hello</div>',
+            header: '<div class="header-slot">Header</div>',
+            footer: '<div class="footer-slot">Footer</div>'
+          },
+          global: { stubs }
+        })
+      })
+
+      BddTest().then('it should render the confirm button', () => {
+        const buttons = wrapper.findAllComponents({ name: 'AvButton' })
+        expect(buttons).toHaveLength(2)
+
+        expect(buttons[1].props('label')).toBe(props.confirmButtonLabel)
+        expect(buttons[1].props('variant')).toBe('FLAT')
+      })
+    })
+  })
+
   BddTest().when('the modal is mounted', () => {
     beforeEach(() => {
       wrapper = mount(AvModal, {
@@ -40,10 +70,15 @@ BddTest().given('an AvModal', () => {
     })
 
     BddTest().then('it should render the close button with correct props', () => {
-      const btn = wrapper.findComponent({ name: 'AvButton' })
+      const btn = wrapper.findAllComponents({ name: 'AvButton' })[0]
       expect(btn.exists()).toBe(true)
       expect(btn.props('label')).toBe(props.closeButtonLabel)
-      expect(btn.props('variant')).toBe('DEFAULT')
+      expect(btn.props('variant')).toBe('OUTLINED')
+    })
+
+    BddTest().then('it should not render the confirm button', () => {
+      const buttons = wrapper.findAllComponents({ name: 'AvButton' })
+      expect(buttons).toHaveLength(1)
     })
 
     BddTest().then('it should emit "close" when the button is clicked', async () => {

--- a/src/components/overlay/modals/AvModal/AvModal.test.ts
+++ b/src/components/overlay/modals/AvModal/AvModal.test.ts
@@ -1,7 +1,7 @@
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, expect } from 'vitest'
 import { nextTick } from 'vue'
-import { AvButtonStub } from '@/components/interaction/buttons/AvButton/AvButton.stub'
+import { AvCancelConfirmButtonsStub } from '@/components/interaction/buttons/AvCancelConfirmButtons/AvCancelConfirmButtons.stub'
 import AvModal, { type AvModalProps } from '@/components/overlay/modals/AvModal/AvModal.vue'
 import { DsfrModalStub } from '@/tests'
 import { BddTest } from '@/tests/utils'
@@ -10,7 +10,7 @@ BddTest().given('an AvModal', () => {
   let wrapper: VueWrapper<InstanceType<typeof AvModal>>
 
   const stubs = {
-    AvButton: AvButtonStub,
+    AvCancelConfirmButtons: AvCancelConfirmButtonsStub,
     DsfrModal: DsfrModalStub,
     Teleport: true
   }
@@ -41,11 +41,9 @@ BddTest().given('an AvModal', () => {
       })
 
       BddTest().then('it should render the confirm button', () => {
-        const buttons = wrapper.findAllComponents({ name: 'AvButton' })
-        expect(buttons).toHaveLength(2)
-
-        expect(buttons[1].props('label')).toBe(props.confirmButtonLabel)
-        expect(buttons[1].props('variant')).toBe('FLAT')
+        const buttons = wrapper.findComponent({ name: 'AvCancelConfirmButtons' })
+        expect(buttons.exists()).toBe(true)
+        expect(buttons.text()).toContain(propsWithConfirm.confirmButtonLabel)
       })
     })
   })
@@ -70,21 +68,15 @@ BddTest().given('an AvModal', () => {
     })
 
     BddTest().then('it should render the close button with correct props', () => {
-      const btn = wrapper.findAllComponents({ name: 'AvButton' })[0]
-      expect(btn.exists()).toBe(true)
-      expect(btn.props('label')).toBe(props.closeButtonLabel)
-      expect(btn.props('variant')).toBe('OUTLINED')
+      const buttons = wrapper.findComponent({ name: 'AvCancelConfirmButtons' })
+      expect(buttons.exists()).toBe(true)
+      expect(buttons.text()).toBe(props.closeButtonLabel)
     })
 
-    BddTest().then('it should not render the confirm button', () => {
-      const buttons = wrapper.findAllComponents({ name: 'AvButton' })
-      expect(buttons).toHaveLength(1)
-    })
-
-    BddTest().then('it should emit "close" when the button is clicked', async () => {
-      const btn = wrapper.findComponent({ name: 'AvButton' })
-      expect(btn.exists()).toBe(true)
-      await btn.trigger('click')
+    BddTest().then('it should emit "close" when the close button is clicked', async () => {
+      const buttons = wrapper.findComponent({ name: 'AvCancelConfirmButtons' })
+      expect(buttons.exists()).toBe(true)
+      await buttons.find('.cancel').trigger('click')
       expect(wrapper.emitted('close')).toHaveLength(1)
     })
 
@@ -97,7 +89,7 @@ BddTest().given('an AvModal', () => {
     BddTest().then('it should pass isLoading to the button', async () => {
       wrapper.setProps({ isLoading: true })
       await nextTick()
-      const btn = wrapper.findComponent({ name: 'AvButton' })
+      const btn = wrapper.findComponent({ name: 'AvCancelConfirmButtons' })
       expect(btn.props('isLoading')).toBe(true)
     })
   })

--- a/src/components/overlay/modals/AvModal/AvModal.vue
+++ b/src/components/overlay/modals/AvModal/AvModal.vue
@@ -1,18 +1,12 @@
 <script setup lang="ts">
 import type { Slot } from 'vue'
-import { AvButton, type AvButtonProps } from '@/components/interaction'
+import { AvButton } from '@/components/interaction'
 import { MDI_ICONS } from '@/tokens'
 
 /**
  * AvModal component props.
  */
 export interface AvModalProps {
-  /**
-   * Variant of the close button: without border (`DEFAULT`) or with border (`OUTLINED`).
-   * @default 'DEFAULT'
-   */
-  closeButtonVariant?: AvButtonProps['variant']
-
   /**
    * Unique identifier for the modal.
    * @default useRandomId('modal', 'dialog')
@@ -56,6 +50,17 @@ export interface AvModalProps {
   closeButtonLabel: string
 
   /**
+   * Label and title (for accessibility) of the confirm button.
+   */
+  confirmButtonLabel?: string
+
+  /**
+   * Icon name of the confirm button.
+   * @default 'mdi:check-circle-outline'
+   */
+  confirmButtonIcon?: string
+
+  /**
    * Adds a loading state on the close button.
    */
   isLoading?: boolean
@@ -67,9 +72,11 @@ const { isLoading, ...props } = defineProps<AvModalProps>()
  * Events emitted by the component.
  *
  * @event close - Event emitted when the modal is closed.
+ * @event close - Event emitted when the confirm button is clicked.
  */
 const emit = defineEmits<{
   (e: 'close'): void
+  (e: 'confirm'): void
 }>()
 
 /**
@@ -85,7 +92,7 @@ const slots = defineSlots<{
   footer?: Slot
 }>()
 
-const closeButtonVariant = computed(() => props.closeButtonVariant ?? 'DEFAULT')
+const confirmButtonIcon = computed(() => props.confirmButtonIcon ?? MDI_ICONS.CHECK_CIRCLE_OUTLINE)
 </script>
 
 <template>
@@ -110,10 +117,20 @@ const closeButtonVariant = computed(() => props.closeButtonVariant ?? 'DEFAULT')
             :icon="MDI_ICONS.CLOSE_CIRCLE_OUTLINE"
             :label="props.closeButtonLabel"
             :title="props.closeButtonLabel"
-            :variant="closeButtonVariant"
+            variant="OUTLINED"
             :is-loading="isLoading"
             size="sm"
             @click="() => emit('close')"
+          />
+          <AvButton
+            v-if="!!props.confirmButtonLabel"
+            :icon="confirmButtonIcon"
+            :label="props.confirmButtonLabel"
+            :title="props.confirmButtonLabel"
+            variant="FLAT"
+            :is-loading="isLoading"
+            size="sm"
+            @click="() => emit('confirm')"
           />
           <slot name="footer" />
         </div>

--- a/src/components/overlay/modals/AvModal/AvModal.vue
+++ b/src/components/overlay/modals/AvModal/AvModal.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type { Slot } from 'vue'
-import { AvButton } from '@/components/interaction'
 import { MDI_ICONS } from '@/tokens'
 
 /**
@@ -72,7 +71,7 @@ const { isLoading, ...props } = defineProps<AvModalProps>()
  * Events emitted by the component.
  *
  * @event close - Event emitted when the modal is closed.
- * @event close - Event emitted when the confirm button is clicked.
+ * @event confirm - Event emitted when the confirm button is clicked.
  */
 const emit = defineEmits<{
   (e: 'close'): void
@@ -113,24 +112,14 @@ const confirmButtonIcon = computed(() => props.confirmButtonIcon ?? MDI_ICONS.CH
       </template>
       <template #footer>
         <div class="footer">
-          <AvButton
-            :icon="MDI_ICONS.CLOSE_CIRCLE_OUTLINE"
-            :label="props.closeButtonLabel"
-            :title="props.closeButtonLabel"
-            variant="OUTLINED"
+          <AvCancelConfirmButtons
+            :cancel-label="props.closeButtonLabel"
+            :cancel-icon="MDI_ICONS.CLOSE_CIRCLE_OUTLINE"
+            :confirm-label="props.confirmButtonLabel"
+            :confirm-icon="confirmButtonIcon"
             :is-loading="isLoading"
-            size="sm"
-            @click="() => emit('close')"
-          />
-          <AvButton
-            v-if="!!props.confirmButtonLabel"
-            :icon="confirmButtonIcon"
-            :label="props.confirmButtonLabel"
-            :title="props.confirmButtonLabel"
-            variant="FLAT"
-            :is-loading="isLoading"
-            size="sm"
-            @click="() => emit('confirm')"
+            @cancel="() => emit('close')"
+            @confirm="() => emit('confirm')"
           />
           <slot name="footer" />
         </div>


### PR DESCRIPTION
- :sparkles: add AvCancelConfirmButtons
- :sparkles: AvModal - add a confirm button
- :lipstick: AvModal - set the close button variant to OUTLINED

AvCancelConfirmButtons example:
<img width="427" height="169" alt="image" src="https://github.com/user-attachments/assets/76141e20-b71d-4b8b-b697-a3b56b186a52" />


https://github.com/avenirs-esr/AVENIRS-Project/issues/685