### PR TITLE
feat: add useBreakpoint composable

### DIFF
--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -1,1 +1,2 @@
+export * from './use-breakpoint/use-breakpoint'
 export * from './use-focus-trap/use-focus-trap'

--- a/src/composables/use-breakpoint/use-breakpoint.test.ts
+++ b/src/composables/use-breakpoint/use-breakpoint.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, expect, vi } from 'vitest'
+import { useBreakpoint } from '@/composables/use-breakpoint/use-breakpoint'
+import { BREAKPOINTS } from '@/config/breakpoints'
+import { BddTest, mountComposable } from '@/tests/utils'
+
+BddTest().given('an useBreakpoint composable', () => {
+  let addEventListenerSpy: ReturnType<typeof vi.spyOn>
+  let removeEventListenerSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    addEventListenerSpy = vi.spyOn(window, 'addEventListener')
+    removeEventListenerSpy = vi.spyOn(window, 'removeEventListener')
+  })
+
+  BddTest().when('the composable is mounted', () => {
+    BddTest().then('it should add a resize event listener', () => {
+      const { unmount } = mountComposable(() => useBreakpoint())
+      expect(addEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function))
+      unmount()
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function))
+    })
+  })
+
+  BddTest().when('checking respondBelow and respondTo', () => {
+    BddTest().then('they should return correct booleans for current window.innerWidth', () => {
+      const { result, unmount } = mountComposable(() => useBreakpoint())
+
+      expect(result.respondBelow(BREAKPOINTS.MD).value).toBe(window.innerWidth <= BREAKPOINTS.MD - 1)
+      expect(result.respondTo(BREAKPOINTS.MD).value).toBe(window.innerWidth >= BREAKPOINTS.MD)
+
+      unmount()
+    })
+  })
+
+  BddTest().when('window is resized', () => {
+    BddTest().then('respondBelow and respondTo should update reactively', async () => {
+      const { result, unmount } = mountComposable(() => useBreakpoint())
+      const resizeHandler = addEventListenerSpy.mock.calls.find(
+        call => call[0] === 'resize'
+      )?.[1] as EventListener
+
+      window.innerWidth = 500
+      resizeHandler(new Event('resize'))
+
+      expect(result.respondBelow(BREAKPOINTS.MD).value).toBe(true)
+      expect(result.respondTo(BREAKPOINTS.MD).value).toBe(false)
+
+      window.innerWidth = 1200
+      resizeHandler(new Event('resize'))
+
+      expect(result.respondBelow(BREAKPOINTS.MD).value).toBe(false)
+      expect(result.respondTo(BREAKPOINTS.MD).value).toBe(true)
+
+      unmount()
+    })
+  })
+})

--- a/src/composables/use-breakpoint/use-breakpoint.ts
+++ b/src/composables/use-breakpoint/use-breakpoint.ts
@@ -1,0 +1,74 @@
+import type { ComputedRef } from 'vue'
+import type { BREAKPOINTS } from '@/config'
+
+/**
+ * Result returned by the useBreakpoint composable.
+ */
+export interface UseBreakpointReturn {
+  /**
+   * Returns a computed boolean that is `true` when the viewport width
+   * is strictly **below** the given breakpoint (`max-width: bp - 1px`).
+   *
+   * Equivalent to the Sass mixin: `@include respond-below($breakpoint)`
+   *
+   * @example
+   * ```ts
+   * const isMobile = respondBelow(BREAKPOINTS.MD) // true if width <= 767px
+   * ```
+   */
+  respondBelow: (bp: BREAKPOINTS) => ComputedRef<boolean>
+
+  /**
+   * Returns a computed boolean that is `true` when the viewport width
+   * is **at or above** the given breakpoint (`min-width: bp`).
+   *
+   * Equivalent to the Sass mixin: `@include respond-to($breakpoint)`
+   *
+   * @example
+   * ```ts
+   * const isDesktop = respondTo(BREAKPOINTS.LG) // true if width >= 1024px
+   * ```
+   */
+  respondTo: (bp: BREAKPOINTS) => ComputedRef<boolean>
+}
+
+/**
+ * Vue composable to handle responsive breakpoints based on the current viewport width.
+ *
+ * This composable provides reactive utilities (`respondBelow` and `respondTo`)
+ * that mirror the behavior of the Sass mixins `@include respond-below($breakpoint)`
+ * and `@include respond-to($breakpoint)`, allowing you to keep logic and styles
+ * perfectly in sync.
+ *
+ * @example
+ * ```ts
+ * const { respondBelow, respondTo } = useBreakpoint()
+ *
+ * const isMobile = respondBelow(BREAKPOINTS.MD) // true if width < 768px
+ * const isDesktop = respondTo(BREAKPOINTS.LG)  // true if width >= 1024px
+ * ```
+ *
+ * @returns {UseBreakpointReturn} Object containing:
+ *  - `respondBelow`: Returns a computed boolean (`true` if width < breakpoint),
+ *  - `respondTo`: Returns a computed boolean (`true` if width >= breakpoint).
+ *
+ * @see BREAKPOINTS for the defined responsive thresholds.
+ */
+export function useBreakpoint (): UseBreakpointReturn {
+  const width = ref(window.innerWidth)
+
+  const onResize = () => {
+    width.value = window.innerWidth
+  }
+
+  onMounted(() => window.addEventListener('resize', onResize))
+  onUnmounted(() => window.removeEventListener('resize', onResize))
+
+  const respondBelow = (bp: BREAKPOINTS) =>
+    computed(() => width.value <= bp - 1)
+
+  const respondTo = (bp: BREAKPOINTS) =>
+    computed(() => width.value >= bp)
+
+  return { respondBelow, respondTo }
+}

--- a/src/config/breakpoints.ts
+++ b/src/config/breakpoints.ts
@@ -1,0 +1,10 @@
+/**
+ * Breakpoints as defined in src/styles/breakpoints.scss
+ * Values are in px to be able to work with window.with
+ */
+export enum BREAKPOINTS {
+  SM = 576, /* 36rem */
+  MD = 768, /* 48rem */
+  LG = 1024, /* 64rem */
+  XL = 1440, /* 90rem */
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,1 +1,2 @@
+export * from './breakpoints'
 export * from './page-sizes'


### PR DESCRIPTION
:sparkles: add a useBreakpoint composable and a BREAKPOINT enum

The composable matches the Sass mixins `@include respond-below($breakpoint)` and `@include respond-to($breakpoint)` defined in `src/styles/breakpoints.scss`

The enum matches the breakpoints value defined in `src/styles/breakpoints.scss`