### PR TITLE
refactor(1110): AvIconText - auto compute size and update align to start

### DIFF
--- a/src/components/base/AvIconText/AvIconText.stories.ts
+++ b/src/components/base/AvIconText/AvIconText.stories.ts
@@ -81,7 +81,7 @@ const meta: Meta<AvIconTextProps> = {
     icon: iconOptions[0],
     text: 'Example text with icon',
     typographyClass: 'b2-regular',
-    gap: 'var(--spacing-xxs)',
+    gap: 'var(--spacing-xs)',
     inline: false,
   },
 }

--- a/src/components/base/AvIconText/AvIconText.stories.ts
+++ b/src/components/base/AvIconText/AvIconText.stories.ts
@@ -36,8 +36,8 @@ const typographyClasses = [
  *   <span class="b2-regular">
  *     The <code>AvIconText</code> is a component that allows you to display text with an icon on the left
  *     (preferably an
- *     <a href="https://icon-sets.iconify.design/mdi/" target="_blank" rel="noopener noreferrer">MDI</a>
- *     icon). This View component is ideal for displaying text with an icon that allows you to visualize
+ *     <a href="https://icon-sets.iconify.design/mdi/" target="_blank" rel="noopener noreferrer">MDI</a> icon).
+ *     This View component is ideal for displaying text with an icon that allows you to visualize
  *     the type of information conveyed by the text.
  *   </span>
  * </p>

--- a/src/components/base/AvIconText/AvIconText.test.ts
+++ b/src/components/base/AvIconText/AvIconText.test.ts
@@ -1,6 +1,7 @@
 import { mount, type VueWrapper } from '@vue/test-utils'
-import { beforeEach, expect } from 'vitest'
+import { beforeEach, expect, vi } from 'vitest'
 import AvIconText from '@/components/base/AvIconText/AvIconText.vue'
+import { DEFAULT_ICON_SIZE_REM } from '@/components/base/AvIconText/utils'
 import { AvIconStub } from '@/tests'
 import { BddTest } from '@/tests/utils'
 import { MDI_ICONS } from '@/tokens'
@@ -80,27 +81,41 @@ BddTest().given('an AvIconText', () => {
       })
     })
 
-    BddTest().and('given a caption typographyClass', () => {
+    BddTest().and('given a specific line height', () => {
+      const expectedIconSize = 3
+
       beforeEach(() => {
-        wrapper = mount(AvIconText, { props: { ...baseProps, typographyClass: 'caption-regular' }, global: { stubs } })
+        vi.spyOn(window, 'getComputedStyle').mockReturnValue({
+          lineHeight: `${expectedIconSize}rem`,
+          fontSize: '1rem',
+        } as CSSStyleDeclaration)
+
+        wrapper = mount(AvIconText, { props: { ...baseProps }, global: { stubs } })
       })
 
-      BddTest().then('it should render the icon accordingly', () => {
+      BddTest().then('it should update the icon size accordingly', async () => {
         const icon = wrapper.findComponent({ name: 'AvIcon' })
         expect(icon.exists()).toBe(true)
-        expect(icon.props('size')).toBe(1.125)
+        expect(icon.props('size')).toBe(expectedIconSize)
       })
     })
 
-    BddTest().and('given a title typographyClass', () => {
+    BddTest().and('given null line height and font size', () => {
+      const expectedIconSize = DEFAULT_ICON_SIZE_REM
+
       beforeEach(() => {
-        wrapper = mount(AvIconText, { props: { ...baseProps, typographyClass: 'n6' }, global: { stubs } })
+        vi.spyOn(window, 'getComputedStyle').mockReturnValue({
+          lineHeight: '0',
+          fontSize: '0',
+        } as CSSStyleDeclaration)
+
+        wrapper = mount(AvIconText, { props: { ...baseProps }, global: { stubs } })
       })
 
-      BddTest().then('it should render the icon accordingly', () => {
+      BddTest().then('it should fallback the icon size to default icon size', async () => {
         const icon = wrapper.findComponent({ name: 'AvIcon' })
         expect(icon.exists()).toBe(true)
-        expect(icon.props('size')).toBe(2)
+        expect(icon.props('size')).toBe(expectedIconSize)
       })
     })
   })

--- a/src/components/base/AvIconText/AvIconText.vue
+++ b/src/components/base/AvIconText/AvIconText.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
+import { nextTick } from 'vue'
 import AvIcon from '@/components/base/AvIcon/AvIcon.vue'
+import { DEFAULT_ICON_SIZE_REM, MAX_ICON_SIZE_REM, MIN_ICON_SIZE_REM } from '@/components/base/AvIconText/utils'
 
 /**
  * AvIconText component props.
@@ -52,18 +54,55 @@ const {
   icon,
   text,
   typographyClass = 'b2-regular',
-  gap = 'var(--spacing-xxs)',
+  gap = 'var(--spacing-xs)',
   inline = false
 } = defineProps<AvIconTextProps>()
 
-const iconSize = computed(() => {
-  if (typographyClass.startsWith('caption')) {
-    return 1.125
+const textElementRef = ref<HTMLElement | null>(null)
+const iconSize = ref(DEFAULT_ICON_SIZE_REM)
+
+function updateIconSize () {
+  if (!textElementRef.value) {
+    iconSize.value = DEFAULT_ICON_SIZE_REM
+    return
   }
-  if (typographyClass.startsWith('n') || typographyClass.startsWith('s')) {
-    return 2
+
+  const textStyle = window.getComputedStyle(textElementRef.value)
+  const rootStyle = window.getComputedStyle(document.documentElement)
+
+  const rootFontSizePx = Number.parseFloat(rootStyle.fontSize)
+  const fontSizePx = Number.parseFloat(textStyle.fontSize)
+  const lineHeightPx = Number.parseFloat(textStyle.lineHeight)
+
+  const baseSizePx = Number.isFinite(lineHeightPx)
+    ? lineHeightPx
+    : fontSizePx
+
+  if (!Number.isFinite(rootFontSizePx) || rootFontSizePx <= 0 || !Number.isFinite(baseSizePx) || baseSizePx <= 0) {
+    iconSize.value = DEFAULT_ICON_SIZE_REM
+    return
   }
-  return 1.3125
+
+  const computedSizeRem = baseSizePx / rootFontSizePx
+  iconSize.value = Math.min(MAX_ICON_SIZE_REM, Math.max(MIN_ICON_SIZE_REM, computedSizeRem))
+}
+
+watch(
+  () => [typographyClass, text],
+  async () => {
+    await nextTick()
+    updateIconSize()
+  },
+  { immediate: true }
+)
+
+onMounted(() => {
+  updateIconSize()
+  window.addEventListener('resize', updateIconSize)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', updateIconSize)
 })
 
 const ellipsisContainerClass = computed(() => !inline ? 'ellipsis-container' : undefined)
@@ -72,7 +111,7 @@ const ellipsisClass = computed(() => !inline ? 'ellipsis' : undefined)
 
 <template>
   <div
-    class="icon-text--container av-row av-align-center"
+    class="icon-text--container av-row av-align-start"
     :class="[ellipsisContainerClass]"
   >
     <AvIcon
@@ -82,6 +121,7 @@ const ellipsisClass = computed(() => !inline ? 'ellipsis' : undefined)
       :size="iconSize"
     />
     <span
+      ref="textElementRef"
       class="icon-text--text"
       :class="[ellipsisClass, typographyClass]"
     >
@@ -94,10 +134,6 @@ const ellipsisClass = computed(() => !inline ? 'ellipsis' : undefined)
 .icon-text--container {
   gap: v-bind('gap');
   max-height: fit-content;
-}
-
-.icon-text--text {
-  color: v-bind('textColor')
 }
 
 .icon-text--text {

--- a/src/components/base/AvIconText/utils.ts
+++ b/src/components/base/AvIconText/utils.ts
@@ -1,0 +1,3 @@
+export const DEFAULT_ICON_SIZE_REM = 1.3125
+export const MIN_ICON_SIZE_REM = 1
+export const MAX_ICON_SIZE_REM = 6

--- a/src/styles/utilities/_border.md
+++ b/src/styles/utilities/_border.md
@@ -1,8 +1,3 @@
----
-layout: page
-lastUpdated: true
----
-
 # Border
 
 ## ✨ Introduction

--- a/src/styles/utilities/_palette.md
+++ b/src/styles/utilities/_palette.md
@@ -1,8 +1,3 @@
----
-layout: page
-lastUpdated: true
----
-
 # Palette
 
 ## ✨ Introduction

--- a/src/styles/utilities/_spacing.md
+++ b/src/styles/utilities/_spacing.md
@@ -1,8 +1,3 @@
----
-layout: page
-lastUpdated: true
----
-
 # Spacing
 
 ## ✨ Introduction


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
<!-- Describe the changes introduced by this pull request. -->

:recycle: AvIconText - auto compute size and update align to start
:memo: Fix DSAV CSS docs rendering

---

### Reference to an Issue, Feature, Task, User Story or another PR
<!-- Mention related issue numbers or links (e.g. Closes #123, Implements #456). -->

Linked to https://github.com/avenirs-esr/AVENIRS-Project/issues/1110

---

### Target Branch
<!-- Which branch is this PR targeting (e.g. `main`, `develop`)? -->

develop

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process

---