### PR TITLE
feat(1249): add AvCheckboxListItem

### DIFF
--- a/a11y/tests/interaction/lists/AvCheckboxListItem.a11y.test.ts
+++ b/a11y/tests/interaction/lists/AvCheckboxListItem.a11y.test.ts
@@ -1,0 +1,11 @@
+import { testStories } from 'a11y/utils'
+
+const component = 'AvCheckboxListItem'
+const title = 'Components/Interaction/Lists/AvCheckboxListItem'
+const stories = [
+  'Default',
+  'WithCustomContent',
+  'WithAccessibility'
+]
+
+testStories(component, title, stories)

--- a/a11y/tests/interaction/lists/AvList.a11y.test.ts
+++ b/a11y/tests/interaction/lists/AvList.a11y.test.ts
@@ -10,6 +10,8 @@ const stories = [
   'SmallSize',
   'MediumSize',
   'LargeSize',
+  'CheckboxList',
+  'CheckboxListCustomItems'
 ]
 
 testStories(component, title, stories)

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -121,6 +121,7 @@ export default defineConfig({
                 {
                   text: 'Lists',
                   items: [
+                    { text: 'AvCheckboxListItem', link: '/components/interaction/lists/AvCheckboxListItem/AvCheckboxListItem.md' },
                     { text: 'AvList', link: '/components/interaction/lists/AvList/AvList.md' },
                     { text: 'AvListItem', link: '/components/interaction/lists/AvListItem/AvListItem.md' },
                   ],

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -49,6 +49,7 @@ _Last updated: 2026-01-06_
 - [AvSearchBar](interaction/inputs/AvSearchBar/AvSearchBar.md)
 
 ### Lists
+- [AvCheckboxListItem](interaction/lists/AvCheckboxListItem/AvCheckboxListItem.md)
 - [AvList](interaction/lists/AvList/AvList.md)
 - [AvListItem](interaction/lists/AvListItem/AvListItem.md)
 

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -21,6 +21,7 @@ declare module 'vue' {
     AvCard: typeof import('./components/cards/AvCard/AvCard.vue')['default']
     AvCheckbox: typeof import('./components/interaction/checkboxes/AvCheckbox/AvCheckbox.vue')['default']
     AvCheckboxesGroup: typeof import('./components/interaction/checkboxes/AvCheckboxesGroup/AvCheckboxesGroup.vue')['default']
+    AvCheckboxListItem: typeof import('./components/interaction/lists/AvCheckboxListItem/AvCheckboxListItem.vue')['default']
     AvDrawer: typeof import('./components/overlay/drawers/AvDrawer/AvDrawer.vue')['default']
     AvDropdown: typeof import('./components/overlay/dropdowns/AvDropdown/AvDropdown.vue')['default']
     AvFieldset: typeof import('./components/base/AvFieldset/AvFieldset.vue')['default']

--- a/src/components/interaction/lists/AvCheckboxListItem/AvCheckboxListItem.md
+++ b/src/components/interaction/lists/AvCheckboxListItem/AvCheckboxListItem.md
@@ -1,0 +1,160 @@
+# Lists - `AvCheckboxListItem`
+
+## ✨ Introduction
+
+The AvCheckboxListItem component represents an individual checkbox item within a list container. It provides a flexible and accessible way to display content with optional icons, titles, descriptions, and interactive capabilities while maintaining consistent styling and behavior patterns.
+
+The `AvCheckboxListItem` component is designed to work seamlessly within `AvList` containers, offering extensive customization for various use cases including navigation menus, content lists, action items, and interactive elements. It supports full accessibility compliance with proper ARIA attributes and keyboard navigation.
+
+It features comprehensive interaction states (hover, focus, active, disabled, selected), flexible content structure with slots, and dynamic tag rendering for different semantic contexts while maintaining visual consistency with the design system.
+
+## 🏗️ Structure
+
+The checkbox list item consists of the following elements:
+- The AvListItem wrapper
+- The icon (optional): Visual indicator displayed between the checkbox and the content
+- The content area (mandatory): Contains label and/or custom content
+- Custom content slot (optional): Allows insertion of any custom elements within the content area
+
+The checkbox list item integrates:
+- Full accessibility support with ARIA attributes and keyboard navigation
+- Comprehensive interaction states and visual feedback
+- Flexible content structure with icon, label, and slot support
+
+## 🏷️ Props
+
+| Name | Type | Default | Mandatory | Description |
+| --- | --- | --- | --- | --- |
+| `id` | `string` | | | Unique ID of the checkbox list item. |
+| `listId` | `string` | | | Unique ID of the parent checkbox list, used for accessibility and focus management. |
+| `label` | `string` | | | Label for the checkbox list item. |
+| `icon` | `string` | | | Icon to display alongside the checkbox list item. |
+| `disabled` | `boolean` | `false` | | Whether the checkbox list item is disabled. |
+| `ariaLabel` | `string` | | | Custom ARIA label for accessibility. |
+| `ariaDescribedby` | `string` | | | ID of element that describes the list item. |
+
+## 🔊 Events
+
+None.
+
+## 🎨 Slots
+
+| Name | Description |
+| --- | --- |
+| `default` | Default slot for custom content within the ckeckbox list item. |
+
+## 🚀 Storybook demos
+
+You can find examples of use and demo of the component on its dedicated [Storybook page](https://avenirs-esr.github.io/avenirs-dsav/storybook/?path=/docs/components-interaction-lists-avcheckboxlistitem--docs).
+
+## 💡 Examples of use
+
+### Basic Checkbox List Item
+
+```vue
+<script lang="ts" setup>
+const selectedItems = ref<string[]>([])
+</script>
+
+<template>
+  <AvList>
+    <AvCheckboxListItem
+      id="first-item"
+      v-model="selectedItems"
+      list-id="checkbox-list"
+      label="First Item"
+    />
+    <AvCheckboxListItem
+      id="second-item"
+      v-model="selectedItems"
+      list-id="checkbox-list"
+      label="Second Item"
+    />
+    <AvCheckboxListItem
+      id="third-item"
+      v-model="selectedItems"
+      list-id="checkbox-list"
+      label="Third Item (disabled)"
+      :disabled="true"
+    />
+  </AvList>
+</template>
+```
+
+### Checkbox List Item with Icon
+
+```vue
+<script lang="ts" setup>
+import { MDI_ICONS } from '@/utils/constants'
+
+const selectedItems = ref<string[]>([])
+</script>
+
+<template>
+  <AvList>
+    <AvCheckboxListItem
+      id="first-item"
+      v-model="selectedItems"
+      list-id="checkbox-list"
+      label="First Item"
+    />
+    <AvCheckboxListItem
+      id="second-item"
+      v-model="selectedItems"
+      list-id="checkbox-list"
+      label="Second Item"
+      :icon="MDI_ICONS.STAR"
+    />
+    <AvCheckboxListItem
+      id="third-item"
+      v-model="selectedItems"
+      list-id="checkbox-list"
+      label="Third Item (disabled)"
+      :disabled="true"
+    />
+  </AvList>
+</template>
+```
+
+### Checkbox List Item with Custom Content
+
+```vue
+<script lang="ts" setup>
+const selectedItems = ref<string[]>([])
+</script>
+
+<template>
+  <AvList>
+    <AvCheckboxListItem
+      id="first-item"
+      v-model="selectedItems"
+      list-id="checkbox-list"
+    >
+      <div class="custom-content">
+        <h3>First Item</h3>
+        <p>This is a custom description for the first item.</p>
+      </div>
+    </AvCheckboxListItem>
+    <AvCheckboxListItem
+      id="second-item"
+      v-model="selectedItems"
+      list-id="checkbox-list"
+    >
+      <div class="custom-content">
+        <h3>Second Item</h3>
+        <p>This is a custom description for the second item.</p>
+      </div>
+    </AvCheckboxListItem>
+    <AvCheckboxListItem
+      id="third-item"
+      v-model="selectedItems"
+      list-id="checkbox-list"
+      :disabled="true"
+    >
+      <div class="custom-content">
+        <h3>Third Item (disabled)</h3>
+        <p>This is a custom description for the third item.</p>
+      </div>
+    </AvCheckboxListItem>
+  </AvList>
+</template>

--- a/src/components/interaction/lists/AvCheckboxListItem/AvCheckboxListItem.stories.ts
+++ b/src/components/interaction/lists/AvCheckboxListItem/AvCheckboxListItem.stories.ts
@@ -1,0 +1,181 @@
+import type { Meta, StoryFn } from '@storybook/vue3'
+import AvCheckboxListItem, { type AvCheckboxListItemProps } from '@/components/interaction/lists/AvCheckboxListItem/AvCheckboxListItem.vue'
+import AvList from '@/components/interaction/lists/AvList/AvList.vue'
+import { MDI_ICONS } from '@/tokens'
+import { iconMappingWithDataUrl, iconOptionsWithDataUrl } from '@/utils/storybook'
+
+/**
+ * <h1 class="n1">Lists - <code>AvCheckboxListItem</code></h1>
+ *
+ * <h2 class="n2">✨ Introduction</h2>
+ *
+ * <p>
+ *   <span class="b2-regular">
+ *     The <code>AvCheckboxListItem</code> component represents an individual checkbox item within a list container.
+ *     It provides a flexible and accessible way to display content with optional icons, titles, descriptions,
+ *     and interactive capabilities while maintaining consistent styling and behavior patterns.
+ *   </span>
+ * </p>
+ *
+ * <p>
+ *   <span class="b2-regular">
+ *     It is designed to work seamlessly within <code>AvList</code> containers, offering extensive customization
+ *     for various use cases such as navigation menus, content lists, action items, and interactive elements.
+ *     It ensures full accessibility compliance with proper ARIA attributes and keyboard navigation.
+ *   </span>
+ * </p>
+ *
+ * <p>
+ *   <span class="b2-regular">
+ *     The component supports multiple interaction states (hover, focus, active, disabled, selected),
+ *     a flexible content structure with slots, and dynamic tag rendering for different semantic contexts,
+ *     while maintaining visual consistency with the design system.
+ *   </span>
+ * </p>
+ *
+ * <h2 class="n2">🏗️ Structure</h2>
+ *
+ * <ul>
+ *   <li>
+ *     <span class="b2-regular">
+ *       The <code>AvListItem</code> wrapper.
+ *     </span>
+ *   </li>
+ *   <li>
+ *     <span class="b2-regular">
+ *       An optional icon displayed between the checkbox and the content.
+ *     </span>
+ *   </li>
+ *   <li>
+ *     <span class="b2-regular">
+ *       A mandatory content area containing the label and/or custom content.
+ *     </span>
+ *   </li>
+ *   <li>
+ *     <span class="b2-regular">
+ *       An optional custom content slot allowing insertion of any custom elements within the content area.
+ *     </span>
+ *   </li>
+ * </ul>
+ *
+ * <p>
+ *   <span class="b2-regular">
+ *     The component integrates full accessibility support (ARIA attributes and keyboard navigation),
+ *     comprehensive interaction states, and a flexible content structure with icon, label, and slot support.
+ *   </span>
+ * </p>
+ */
+const meta: Meta<AvCheckboxListItemProps> = {
+  title: 'Components/Interaction/Lists/AvCheckboxListItem',
+  component: AvCheckboxListItem,
+  tags: ['autodocs'],
+  argTypes: {
+    id: { control: 'text' },
+    listId: { control: 'text' },
+    label: { control: 'text' },
+    icon: {
+      control: 'select',
+      options: ['', ...iconOptionsWithDataUrl],
+      mapping: {
+        '': '',
+        ...iconMappingWithDataUrl,
+      },
+    },
+    disabled: { control: 'boolean' },
+    ariaLabel: { control: 'text' },
+    ariaDescribedby: { control: 'text' }
+  },
+  args: {
+    id: 'checkbox-list-item',
+    listId: 'checkbox-list',
+  }
+}
+
+export default meta
+
+const Template: StoryFn<AvCheckboxListItemProps> = args => ({
+  components: { AvList, AvCheckboxListItem },
+  setup () {
+    const selected = ref<string[]>([])
+    return {
+      args,
+      selected,
+      MDI_ICONS
+    }
+  },
+  template: `
+    <div style="max-width: 20rem;">
+      <AvList>
+        <AvCheckboxListItem v-bind="args" v-model="selected" />
+      </AvList>
+    </div>
+  `
+})
+
+export const Default = Template.bind({})
+Default.args = {
+  label: 'Default List Item',
+  id: 'default-item',
+  listId: 'default-list',
+}
+
+const TemplateCheckboxListItemCustom: StoryFn<AvCheckboxListItemProps> = args => ({
+  components: { AvList, AvCheckboxListItem },
+  setup () {
+    const selected = ref<(string | number)[]>([])
+
+    return {
+      args,
+      selected,
+      MDI_ICONS
+    }
+  },
+  template: `
+    <AvList>
+      <AvCheckboxListItem v-model="selected" v-bind="args">
+        <span class="b2-bold">Custom item <span class="caption-light">with caption light description</span></span>
+      </AvCheckboxListItem>
+    </AvList>
+  `
+})
+
+export const WithCustomContent = TemplateCheckboxListItemCustom.bind({})
+WithCustomContent.args = {
+  label: 'Custom Content',
+  icon: MDI_ICONS.DOTS_VERTICAL,
+  id: 'custom-content-item',
+  listId: 'custom-content-list'
+}
+
+const TemplateAccessibility: StoryFn<AvCheckboxListItemProps> = args => ({
+  components: { AvList, AvCheckboxListItem },
+  setup () {
+    const selected = ref<(string | number)[]>([])
+
+    return {
+      args,
+      selected,
+      MDI_ICONS
+    }
+  },
+  template: `
+    <div style="max-width: 20rem;">
+      <AvList>
+        <AvCheckboxListItem v-bind="args" v-model="selected" />
+      </AvList>
+      <p id="helper-text" style="margin-top: 0.5rem; font-size: 0.875rem; color: #6b7280;">
+        This text provides additional context for screen readers
+      </p>
+    </div>
+  `
+})
+
+export const WithAccessibility = TemplateAccessibility.bind({})
+WithAccessibility.args = {
+  label: 'Accessible Item',
+  icon: MDI_ICONS.INFORMATION_OUTLINE,
+  ariaLabel: 'Custom accessible label for screen readers',
+  ariaDescribedby: 'helper-text',
+  id: 'accessible-item',
+  listId: 'accessible-list'
+}

--- a/src/components/interaction/lists/AvCheckboxListItem/AvCheckboxListItem.stub.ts
+++ b/src/components/interaction/lists/AvCheckboxListItem/AvCheckboxListItem.stub.ts
@@ -1,0 +1,31 @@
+export const AvCheckboxListItemStub = defineComponent({
+  name: 'AvCheckboxListItem',
+  props: {
+    id: { type: String, required: true },
+    listId: { type: String, required: true },
+    label: String,
+    icon: String,
+    disabled: Boolean,
+    ariaLabel: String,
+    ariaLabelledby: String,
+    modelValue: { type: Array, required: true },
+  },
+  emits: ['update:modelValue'],
+  template: `
+    <div class="av-checkbox-list-item-stub">
+      <input
+        type="checkbox"
+        :id="id"
+        :name="name"
+        :checked="modelValue.includes(id)"
+        @change="$emit('update:modelValue', 
+          modelValue.includes(id)
+            ? modelValue.filter(v => v !== id)
+            : [...modelValue, id]
+        )"
+        :data-testid="'checkbox-' + id"
+      />
+      <label :for="id"><slot name="label">{{ label }}</slot></label>
+    </div>
+  `
+})

--- a/src/components/interaction/lists/AvCheckboxListItem/AvCheckboxListItem.test.ts
+++ b/src/components/interaction/lists/AvCheckboxListItem/AvCheckboxListItem.test.ts
@@ -1,0 +1,106 @@
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, expect } from 'vitest'
+import AvCheckboxListItem, { type AvCheckboxListItemProps } from '@/components/interaction/lists/AvCheckboxListItem/AvCheckboxListItem.vue'
+import { AvCheckboxStub, AvListItemStub } from '@/tests'
+import { BddTest } from '@/tests/utils'
+
+BddTest().given('an AvCheckboxListItem component', () => {
+  let wrapper: VueWrapper<InstanceType<typeof AvCheckboxListItem>>
+
+  const props: AvCheckboxListItemProps & { modelValue: string[] } = {
+    id: 'test-item',
+    listId: 'test-list',
+    label: 'Test Item',
+    modelValue: [],
+  }
+
+  const stubs = {
+    AvCheckbox: AvCheckboxStub,
+    AvListItem: AvListItemStub
+  }
+
+  BddTest().when('the component is mounted', () => {
+    beforeEach(() => {
+      wrapper = mount(AvCheckboxListItem, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should render an AvListItem', () => {
+      expect(wrapper.findComponent(AvListItemStub).exists()).toBe(true)
+    })
+
+    BddTest().then('it should render an AvCheckbox', () => {
+      expect(wrapper.findComponent(AvCheckboxStub).exists()).toBe(true)
+    })
+
+    BddTest().and('the user clicks the checkbox', () => {
+      beforeEach(async () => {
+        wrapper.findComponent(AvCheckboxStub).vm.$emit('update:modelValue', ['test-item'])
+      })
+
+      BddTest().then('it should emit an update:modelValue event with the item id', () => {
+        expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+        expect(wrapper.emitted('update:modelValue')![0][0]).toEqual(['test-item'])
+      })
+    })
+
+    BddTest().and('focusing the checkbox', () => {
+      let checkboxInput: HTMLInputElement
+      beforeEach(() => {
+        wrapper = mount(AvCheckboxListItem, { props, global: { stubs }, attachTo: document.body })
+        checkboxInput = wrapper.find('input[type="checkbox"]').element as HTMLInputElement
+        checkboxInput.focus()
+      })
+
+      BddTest().then('the checkbox should be focused', () => {
+        expect(document.activeElement).toBe(checkboxInput)
+      })
+    })
+  })
+})
+
+BddTest().given('multiple AvCheckboxListItem mounted in the DOM', () => {
+  let wrappers: VueWrapper<InstanceType<typeof AvCheckboxListItem>>[]
+  const baseProps = (id: string) => ({
+    id,
+    listId: 'list',
+    label: `Item ${id}`,
+    modelValue: [],
+  })
+  const stubs = {
+    AvCheckbox: AvCheckboxStub,
+    AvListItem: AvListItemStub
+  }
+
+  BddTest().when('the components are mounted with attachTo: document.body', () => {
+    beforeEach(() => {
+      wrappers = [
+        mount(AvCheckboxListItem, { props: baseProps('a'), global: { stubs }, attachTo: document.body }),
+        mount(AvCheckboxListItem, { props: baseProps('b'), global: { stubs }, attachTo: document.body }),
+        mount(AvCheckboxListItem, { props: baseProps('c'), global: { stubs }, attachTo: document.body }),
+      ]
+    })
+    afterEach(() => {
+      wrappers.forEach(w => w.unmount())
+    })
+
+    BddTest().and('the focus is on the first checkbox', () => {
+      let firstInput: HTMLInputElement
+      beforeEach(() => {
+        firstInput = wrappers[0].find('input[type="checkbox"]').element as HTMLInputElement
+        firstInput.focus()
+      })
+
+      BddTest().then('ArrowDown focuses the next checkbox', async () => {
+        const secondInput = wrappers[1].find('input[type="checkbox"]').element as HTMLInputElement
+        await wrappers[0].find('input[type="checkbox"]').trigger('keydown', { key: 'ArrowDown' })
+        expect(document.activeElement).toBe(secondInput)
+      })
+
+      BddTest().then('ArrowUp focuses the last checkbox', async () => {
+        const lastInput = wrappers[2].find('input[type="checkbox"]').element as HTMLInputElement
+        await wrappers[0].find('input[type="checkbox"]').trigger('keydown', { key: 'ArrowUp' })
+        expect(document.activeElement).toBe(lastInput)
+      })
+    })
+  })
+})

--- a/src/components/interaction/lists/AvCheckboxListItem/AvCheckboxListItem.vue
+++ b/src/components/interaction/lists/AvCheckboxListItem/AvCheckboxListItem.vue
@@ -1,0 +1,99 @@
+<script lang="ts" setup>
+import AvCheckbox from '@/components/interaction/checkboxes/AvCheckbox/AvCheckbox.vue'
+
+export interface AvCheckboxListItemProps {
+  /**
+   * Unique ID of the checkbox list item
+   */
+  id: string
+
+  /**
+   * Unique ID of the parent checkbox list, used for accessibility and focus management
+   */
+  listId: string
+
+  /**
+   * Label for the checkbox list item
+   */
+  label?: string
+
+  /**
+   * Icon to display alongside the checkbox list item
+   */
+  icon?: string
+
+  /**
+   * Whether the checkbox list item is disabled
+   */
+  disabled?: boolean
+
+  /**
+   * ARIA label for the list item when clickable.
+   */
+  ariaLabel?: string
+
+  /**
+   * ID of an element that describes the list item.
+   */
+  ariaDescribedby?: string
+}
+
+const { id, listId, ariaLabel, ariaDescribedby } = defineProps<AvCheckboxListItemProps>()
+
+const model = defineModel<(string | number)[]>({ required: true })
+
+function getAllCheckbox (): NodeListOf<HTMLElement> {
+  return document.querySelectorAll(`[id^='${listId}-'][id$='-checkbox']`)
+}
+
+function handleFocusNextCheckbox (event: KeyboardEvent) {
+  event.preventDefault()
+  const checkboxes = getAllCheckbox()
+  const activeElement = document.activeElement as HTMLElement
+  const currentIndex = Array.from(checkboxes).indexOf(activeElement)
+
+  if (currentIndex !== -1) {
+    const nextIndex = (currentIndex + 1) % checkboxes.length
+    checkboxes[nextIndex].focus()
+  }
+}
+
+function handleFocusPreviousCheckbox (event: KeyboardEvent) {
+  event.preventDefault()
+  const checkboxes = getAllCheckbox()
+  const activeElement = document.activeElement as HTMLElement
+  const currentIndex = Array.from(checkboxes).indexOf(activeElement)
+
+  if (currentIndex !== -1) {
+    const previousIndex
+      = (currentIndex - 1 + checkboxes.length) % checkboxes.length
+    checkboxes[previousIndex].focus()
+  }
+}
+</script>
+
+<template>
+  <AvListItem
+    :aria-label="ariaLabel"
+    :aria-describedby="ariaDescribedby"
+    data-testid="av-checkbox-list-item"
+  >
+    <AvCheckbox
+      :id="`${listId}-${id}-checkbox`"
+      v-model="model"
+      :value="id"
+      :name="`${listId}-${id}-checkbox`"
+      :label="label"
+      :icon="icon"
+      :disabled="disabled"
+      @keydown.down="handleFocusNextCheckbox"
+      @keydown.right="handleFocusNextCheckbox"
+      @keydown.up="handleFocusPreviousCheckbox"
+      @keydown.left="handleFocusPreviousCheckbox"
+    >
+      <template #label>
+        <slot />
+      </template>
+    </AvCheckbox>
+  </AvListItem>
+</template>

--- a/src/components/interaction/lists/AvList/AvList.stories.ts
+++ b/src/components/interaction/lists/AvList/AvList.stories.ts
@@ -1,4 +1,5 @@
 import type { Meta, StoryFn } from '@storybook/vue3'
+import AvCheckboxListItem from '@/components/interaction/lists/AvCheckboxListItem/AvCheckboxListItem.vue'
 import AvList, { type AvListProps } from '@/components/interaction/lists/AvList/AvList.vue'
 import AvListItem from '@/components/interaction/lists/AvListItem/AvListItem.vue'
 import { MDI_ICONS } from '@/tokens'
@@ -184,4 +185,64 @@ MediumSize.args = {
 export const LargeSize = Template.bind({})
 LargeSize.args = {
   size: 'large'
+}
+
+const TemplateCheckboxList: StoryFn<AvListProps> = args => ({
+  components: { AvList, AvCheckboxListItem },
+  setup () {
+    const model = ref<(string | number)[]>([])
+
+    return {
+      args,
+      model,
+      MDI_ICONS
+    }
+  },
+  template: `
+    <AvList v-bind="args">
+      <AvCheckboxListItem v-model="model" list-id="checkbox-list" id="first-item" label="First Item" />
+      <AvCheckboxListItem v-model="model" list-id="checkbox-list" id="second-item" label="Second Item" :icon="MDI_ICONS.STAR" />
+      <AvCheckboxListItem v-model="model" list-id="checkbox-list" id="third-item" label="Third Item (disabled)" :disabled="true" />
+    </AvList>
+  `
+})
+
+export const CheckboxList = TemplateCheckboxList.bind({})
+CheckboxList.args = {
+  size: 'xsmall',
+  bordered: true,
+  borderRadius: 'var(--radius-md)',
+  backgroundColor: 'var(--surface-alt)'
+}
+
+const TemplateCheckboxListCustom: StoryFn<AvListProps> = args => ({
+  components: { AvList, AvCheckboxListItem },
+  setup () {
+    const model = ref<(string | number)[]>([])
+
+    return {
+      args,
+      model,
+      MDI_ICONS
+    }
+  },
+  template: `
+    <AvList v-bind="args">
+      <AvCheckboxListItem v-model="model" list-id="checkbox-list" id="first-item">
+        <span class="b2-bold">Custom item <span class="caption-light">with caption light description</span></span>
+      </AvCheckboxListItem>
+      <AvCheckboxListItem v-model="model" list-id="checkbox-list" id="second-item" label="Basic item with icon" :icon="MDI_ICONS.STAR" />
+      <AvCheckboxListItem v-model="model" list-id="checkbox-list" id="third-item" :icon="MDI_ICONS.STAR">
+        <div class="av-col"><span>Custom item on two lines</span><span>and with icon in props</span></div>
+      </AvCheckboxListItem>
+    </AvList>
+  `
+})
+
+export const CheckboxListCustomItems = TemplateCheckboxListCustom.bind({})
+CheckboxListCustomItems.args = {
+  size: 'xsmall',
+  bordered: true,
+  borderRadius: 'var(--radius-md)',
+  backgroundColor: 'var(--surface-alt)'
 }

--- a/src/components/interaction/lists/AvListItem/AvListItem.stories.ts
+++ b/src/components/interaction/lists/AvListItem/AvListItem.stories.ts
@@ -248,13 +248,7 @@ SubCustomColors.args = {
   onClick: () => alert('Custom colors subitem clicked!')
 }
 
-export const WithCustomContent = Template.bind({})
-WithCustomContent.args = {
-  title: 'Custom Content',
-  icon: MDI_ICONS.DOTS_VERTICAL,
-  onClick: () => alert('Custom content item clicked!')
-}
-WithCustomContent.render = args => ({
+const TemplateWithCustomContent: StoryFn<AvListItemProps> = args => ({
   components: { AvList, AvListItem },
   setup () {
     return { args, MDI_ICONS }
@@ -265,7 +259,7 @@ WithCustomContent.render = args => ({
         <AvListItem v-bind="args">
           <div style="display: flex; gap: 0.5rem; margin-top: 0.5rem;">
             <button style="padding: 0.25rem 0.5rem; border: 1px solid #ccc; border-radius: 0.25rem; background: white;">Edit</button>
-            <button style="padding: 0.25rem 0.5rem; border: 1px solid #dc2626; border-radius: 0.25rem; background: #fef2f2; color: #dc2626;">Delete</button>
+            <button style="padding: 0.25rem 0.5rem; border: 1px solid #dc2626; border-radius: 0.25rem; background: #fef2f2;">Delete</button>
           </div>
         </AvListItem>
       </AvList>
@@ -273,16 +267,19 @@ WithCustomContent.render = args => ({
   `
 })
 
-export const WithAccessibility = Template.bind({})
-WithAccessibility.args = {
-  title: 'Accessible Item',
-  description: 'Item with custom accessibility attributes',
-  icon: MDI_ICONS.INFORMATION_OUTLINE,
-  ariaLabel: 'Custom accessible label for screen readers',
-  ariaDescribedby: 'helper-text',
-  onClick: () => alert('Accessible item clicked!')
+export const WithCustomContent = TemplateWithCustomContent.bind({})
+WithCustomContent.args = {
+  title: 'Custom Content',
+  icon: MDI_ICONS.DOTS_VERTICAL,
 }
-WithAccessibility.render = args => ({
+WithCustomContent.render = args => ({
+  components: { AvList, AvListItem },
+  setup () {
+    return { args, MDI_ICONS }
+  },
+})
+
+const TemplateWithAccessibility: StoryFn<AvListItemProps> = args => ({
   components: { AvList, AvListItem },
   setup () {
     return { args, MDI_ICONS }
@@ -298,3 +295,13 @@ WithAccessibility.render = args => ({
     </div>
   `
 })
+
+export const WithAccessibility = TemplateWithAccessibility.bind({})
+WithAccessibility.args = {
+  title: 'Accessible Item',
+  description: 'Item with custom accessibility attributes',
+  icon: MDI_ICONS.INFORMATION_OUTLINE,
+  ariaLabel: 'Custom accessible label for screen readers',
+  ariaDescribedby: 'helper-text',
+  onClick: () => alert('Accessible item clicked!')
+}

--- a/src/tests/index.ts
+++ b/src/tests/index.ts
@@ -11,6 +11,7 @@ import { AvCheckboxStub } from '@/components/interaction/checkboxes/AvCheckbox/A
 import { AvCheckboxesGroupStub } from '@/components/interaction/checkboxes/AvCheckboxesGroup/AvCheckboxesGroup.stub'
 import { AvInputStub } from '@/components/interaction/inputs/AvInput/AvInput.stub'
 import { AvPeriodInputStub } from '@/components/interaction/inputs/AvPeriodInput/AvPeriodInput.stub'
+import { AvCheckboxListItemStub } from '@/components/interaction/lists/AvCheckboxListItem/AvCheckboxListItem.stub'
 import { AvListStub } from '@/components/interaction/lists/AvList/AvList.stub'
 import { AvListItemStub } from '@/components/interaction/lists/AvListItem/AvListItem.stub'
 import { AvTagPickerStub } from '@/components/interaction/pickers/AvTagPicker/AvTagPicker.stub'
@@ -38,6 +39,7 @@ export {
   AvCancelConfirmButtonsStub,
   AvCardStub,
   AvCheckboxesGroupStub,
+  AvCheckboxListItemStub,
   AvCheckboxStub,
   AvDrawerStub,
   AvDropdownStub,


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Ce PR ajoute le composant `AvCheckboxListItem` pour permettre l'affichage et la gestion de listes de cases à cocher accessibles et stylées, avec navigation clavier et intégration dans le design system. Il inclut la documentation, les tests unitaires et a11y, ainsi que l'intégration dans Storybook et la documentation technique.

**Principaux changements :**
- ✨ Ajout du composant `AvCheckboxListItem` (Vue, stories, tests, doc)
- ♿️ Navigation clavier et accessibilité sur les listes de cases à cocher
- ✅ Ajout de tests unitaires et a11y
- 📝 Documentation technique et Storybook
- 🎨 Mise à jour des stories AvList/AvListItem pour intégration

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1249

---

### Documentation
- Ajout : `src/components/interaction/lists/AvCheckboxListItem/AvCheckboxListItem.vue`
- Ajout : `AvCheckboxListItem.stories.ts`, `AvCheckboxListItem.test.ts`, `AvCheckboxListItem.md`, `AvCheckboxListItem.a11y.test.ts`
- Modif : `src/components/interaction/lists/AvList/AvList.stories.ts`, `AvListItem.stories.ts`
- Modif : `docs/components/index.md`, `docs/.vitepress/config.js`
- Modif : `src/components.d.ts`

---

### Target Branch
`develop`

---

### Additional Notes
- Le composant gère la navigation clavier (flèches) sur toute la liste grâce à un id commun (`listId`).
- Les tests a11y garantissent la conformité aux standards d’accessibilité.
- Le composant est prêt à être utilisé dans des listes dynamiques ou statiques.

---

### Known Limitations or Side Effects
Aucune limitation ou effet de bord connu à ce stade.

---

## ✅ Checklist

- [ ] a11y tested (tests a11y fournis)
- [ ] Tests fournis (unitaires et a11y)
- [ ] i18n géré (labels personnalisables)
- [ ] Performance tests (non applicable)
- [ ] Pas de code inutile
- [ ] Respect des règles de style et conventions
- [ ] Versionnement sémantique respecté
- [ ] Ajout dans `CHANGELOG.md` si besoin
