### PR TITLE
fix(1276): AvSideNavigation - add width prop with default value to 'fit-content'

### DIFF
--- a/a11y/tests/navigation/AvSideNavigation.a11y.test.ts
+++ b/a11y/tests/navigation/AvSideNavigation.a11y.test.ts
@@ -7,6 +7,7 @@ const stories = [
   'MenuItems',
   'Collapsed',
   'CustomWidth',
+  'CustomCollapsedWidth',
 ]
 
 testStories(component, title, stories)

--- a/src/components/navigation/AvSideNavigation/AvSideNavigation.md
+++ b/src/components/navigation/AvSideNavigation/AvSideNavigation.md
@@ -24,6 +24,7 @@ The component integrates:
 | Name | Type | Default | Mandatory | Description |
 | --- | --- | --- | --- | --- |
 | `items` | `AvSideNavigationItem[]` | | ✅ | Array of navigation items, each containing id, label, and icon |
+| `width` | `string` | `'fit-content'` | | Width of the side menu when expanded |
 | `collapsedWidth` | `string` | `'3.5rem'` | | Width of the side menu when collapsed |
 | `selectedItemColor` | `string` | `'var(--dark-background-primary1)'` | | Color of selected item background and icon. |
 

--- a/src/components/navigation/AvSideNavigation/AvSideNavigation.stories.ts
+++ b/src/components/navigation/AvSideNavigation/AvSideNavigation.stories.ts
@@ -108,25 +108,25 @@ const meta: Meta<typeof AvSideNavigation> = {
   tags: ['autodocs'],
   argTypes: {
     items: {
-      description: 'Array of navigation items with id, label, and icon',
       control: { type: 'object' }
     },
+    width: {
+      control: { type: 'text' }
+    },
     collapsedWidth: {
-      description: 'Width of the side menu when collapsed',
       control: { type: 'text' }
     },
     selectedItem: {
-      description: 'Currently selected item ID (v-model)',
       control: { type: 'object' }
     },
     isSideMenuCollapsed: {
-      description: 'Whether the side menu is collapsed (v-model)',
       control: { type: 'boolean' }
     }
   },
   args: {
     items: mockItems,
-    collapsedWidth: '3.5rem'
+    collapsedWidth: '3.5rem',
+    width: 'fit-content'
   }
 }
 
@@ -211,7 +211,36 @@ export const Collapsed: Story = {
   })
 }
 
-export const CustomWidth: Story = {
+export const CustomdWidth: Story = {
+  render: args => ({
+    components: { AvSideNavigation },
+    setup () {
+      const selectedItem = ref({ itemId: 'experiences' })
+      const isSideMenuCollapsed = ref(false)
+      return { args, selectedItem, isSideMenuCollapsed }
+    },
+    template: `
+      <div style="height: 400px; display: flex;">
+        <AvSideNavigation 
+          v-bind="args"
+          v-model:selected-item="selectedItem"
+          v-model:is-side-menu-collapsed="isSideMenuCollapsed"
+        />
+        <div style="flex: 1; padding: 1rem; background: #f5f5f5;">
+          <p><strong>Selected item:</strong> {{ selectedItem.itemId }}</p>
+          <p><strong>Parent item:</strong> {{ selectedItem.parentId }}</p>
+          <p><strong>Menu collapsed:</strong> {{ isSideMenuCollapsed }}</p>
+          <p>This story demonstrates custom width (20rem instead of default fit-content).</p>
+        </div>
+      </div>
+    `
+  }),
+  args: {
+    width: '20rem'
+  }
+}
+
+export const CustomCollapsedWidth: Story = {
   render: args => ({
     components: { AvSideNavigation },
     setup () {

--- a/src/components/navigation/AvSideNavigation/AvSideNavigation.vue
+++ b/src/components/navigation/AvSideNavigation/AvSideNavigation.vue
@@ -20,25 +20,34 @@ export interface AvSideNavigationProps {
    * List of items to display in the side navigation.
    */
   items: AvSideNavigationMenuItem[]
+
   /**
    * The currently selected item ID.
    */
   selectedItem?: AvSideNavigationSelectedItem
+
   /**
    * Whether the side menu is collapsed or not.
    */
   isSideMenuCollapsed?: boolean
+
+  /**
+   * Width of the side menu when expanded.
+   */
+  width?: string
+
   /**
    * Width of the side menu when collapsed.
    */
   collapsedWidth?: string
+
   /**
    * Color of selected item background and icon.
    */
   selectedItemColor?: string
 }
 
-const { items, collapsedWidth = '3.5rem', selectedItemColor } = defineProps<AvSideNavigationProps>()
+const { items, width = 'fit-content', collapsedWidth = '3.5rem', selectedItemColor } = defineProps<AvSideNavigationProps>()
 
 const selectedItem = defineModel<AvSideNavigationSelectedItem>('selectedItem', {
   default: () => ({ itemId: '' })
@@ -88,6 +97,7 @@ watchEffect(() => {
 <template>
   <AvSideMenu
     v-model:collapsed="isSideMenuCollapsed"
+    :width="width"
     :collapsed-width="collapsedWidth"
     :color="selectedItemColor"
   >


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR adds a `width` prop to the `AvSideNavigation` component with a default value of `'fit-content'`. This allows consumers to customize the width of the side navigation and improves flexibility and layout control.

**Main changes:**
- ✨ Adds `width` prop with default value to `AvSideNavigation.vue`
- 📝 Updates documentation and stories for the new prop
- ✅ Adds a11y test for the width prop

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1276

---

### Documentation
- Updated `AvSideNavigation.md` and stories to document and demonstrate the new `width` prop.
- Added a11y test for the width prop.

**Modified files:**
- `src/components/navigation/AvSideNavigation/AvSideNavigation.vue`
- `src/components/navigation/AvSideNavigation/AvSideNavigation.md`
- `src/components/navigation/AvSideNavigation/AvSideNavigation.stories.ts`
- `src/components/navigation/tests/navigation/AvSideNavigation.a11y.test.ts`

---

### Target Branch
`develop`

---

### Additional Notes
This change increases the flexibility of the side navigation component and ensures it can be easily integrated into various layouts.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
