### PR TITLE
fix(1299): AvMultiselect - prevent jumps in collapse with scroll and add scroll following focus

### DIFF
--- a/a11y/tests/interaction/selects/AvMultiselect.a11y.test.ts
+++ b/a11y/tests/interaction/selects/AvMultiselect.a11y.test.ts
@@ -6,6 +6,7 @@ const stories = [
   'Default',
   'Dense',
   'OptionsWithIcon',
+  'CollapseMaxHeight',
 ]
 
 testStories(component, title, stories)

--- a/src/components/interaction/lists/AvCheckboxListItem/AvCheckboxListItem.vue
+++ b/src/components/interaction/lists/AvCheckboxListItem/AvCheckboxListItem.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import type { AvListItem } from '@/components/interaction/lists'
 import AvCheckbox from '@/components/interaction/checkboxes/AvCheckbox/AvCheckbox.vue'
 
 export interface AvCheckboxListItemProps {
@@ -70,10 +71,21 @@ function handleFocusPreviousCheckbox (event: KeyboardEvent) {
     checkboxes[previousIndex].focus()
   }
 }
+
+const listItemRef = ref<InstanceType<typeof AvListItem> | null>(null)
+
+function handleCheckboxFocus () {
+  const el = listItemRef.value
+  if (el) {
+    const domEl = (el instanceof HTMLElement) ? el : (el as { $el: HTMLElement }).$el
+    domEl?.scrollIntoView?.({ block: 'nearest' })
+  }
+}
 </script>
 
 <template>
   <AvListItem
+    ref="listItemRef"
     :aria-label="ariaLabel"
     :aria-describedby="ariaDescribedby"
     data-testid="av-checkbox-list-item"
@@ -90,6 +102,7 @@ function handleFocusPreviousCheckbox (event: KeyboardEvent) {
       @keydown.right="handleFocusNextCheckbox"
       @keydown.up="handleFocusPreviousCheckbox"
       @keydown.left="handleFocusPreviousCheckbox"
+      @focus="handleCheckboxFocus"
     >
       <template #label>
         <slot />

--- a/src/components/interaction/selects/AvMultiselect/AvMultiselect.md
+++ b/src/components/interaction/selects/AvMultiselect/AvMultiselect.md
@@ -25,7 +25,6 @@ Inside the list:
 
 | Name             | Type | Default | Mandatory | Description |
 |------------------| --- | --- | --- | --- |
-| `modelValue`     | `(string \| number)[]` | | ✅ | Selected option(s) value(s). |
 | `disabled`       | `boolean` | `false` | | Indicated if the select is disabled.|
 | `options`        | `{ value: string \| number, label: string, icon?: string})[]` | `[]` | | Selectable options. |
 | `label`          | `string` | | ✅ | Select text label.|
@@ -42,11 +41,17 @@ Inside the list:
 | `search`         | `boolean` | `false` | | Displays the search bar.|
 | `width`          | `string` | `undefined` | | Fixes the width of the multiselect.|
 | `height`         | `string` | `undefined` | | Fixes the height of the multiselect.|
+| `collapseMaxHeight` | `string` | `undefined` | | Fixes the max height of the options list.|
+
 ## 🔊 Events
 
-| Name | Data (*payload*) | Description |
+The component uses `defineModel` for selected options.
+
+### Model events
+
+| Model | Type | Description |
 | --- | --- | --- |
-| `'update:modelValue'` | `(string \| number)[]` | Emitted when an option is selected or unselected. |
+| `default` | `{ value: string \| number, label: string, icon?: string})[]` | Current selected options |
 
 ## 🎨 Slots
 

--- a/src/components/interaction/selects/AvMultiselect/AvMultiselect.stories.ts
+++ b/src/components/interaction/selects/AvMultiselect/AvMultiselect.stories.ts
@@ -88,6 +88,7 @@ const meta = {
     dense: false,
     selectAll: false,
     search: false,
+    selectedText: 'Option(s) sélectionnée(s)',
   },
   parameters: {
     docs: {
@@ -129,4 +130,22 @@ OptionsWithIcon.args = {
     { value: '5', label: 'Choice 5', icon: MDI_ICONS.IMAGE_OUTLINE },
   ],
   label: 'Options with icon',
+}
+
+export const CollapseMaxHeight = Template.bind({})
+CollapseMaxHeight.args = {
+  options: [
+    { value: '1', label: 'Choice 1', icon: MDI_ICONS.ATTACH_FILE },
+    { value: '2', label: 'Choice 2', icon: MDI_ICONS.CHAT_ALERT },
+    { value: '3', label: 'Choice 3', icon: MDI_ICONS.CONTENT_SAVE_OUTLINE },
+    { value: '4', label: 'Choice 4', icon: MDI_ICONS.ELECTRON_FRAMEWORK },
+    { value: '5', label: 'Choice 5', icon: MDI_ICONS.IMAGE_OUTLINE },
+    { value: '6', label: 'Choice 6', icon: MDI_ICONS.ATTACH_FILE },
+    { value: '7', label: 'Choice 7', icon: MDI_ICONS.CHAT_ALERT },
+    { value: '8', label: 'Choice 8', icon: MDI_ICONS.CONTENT_SAVE_OUTLINE },
+    { value: '9', label: 'Choice 9', icon: MDI_ICONS.ELECTRON_FRAMEWORK },
+    { value: '10', label: 'Choice 10', icon: MDI_ICONS.IMAGE_OUTLINE },
+  ],
+  label: 'Collapse max height',
+  collapseMaxHeight: '150px',
 }

--- a/src/components/interaction/selects/AvMultiselect/AvMultiselect.stub.ts
+++ b/src/components/interaction/selects/AvMultiselect/AvMultiselect.stub.ts
@@ -1,0 +1,42 @@
+export const AvMultiselectStub = defineComponent({
+  name: 'AvMultiselect',
+  props: {
+    modelValue: Array,
+    options: Array,
+    label: String,
+    placeholder: String,
+    selectedText: String,
+    dense: Boolean
+  },
+  emits: ['update:modelValue'],
+  template: `
+    <div :class="{ 'av-multiselect--dense': dense }">
+      <label>{{ label }}</label>
+      <select
+        multiple
+        :value="modelValue.map(o => o.value)"
+        @change="$emit(
+          'update:modelValue',
+          Array.from($event.target.selectedOptions).map(o => ({
+            label: o.text,
+            value: o.value
+          }))
+        )"
+      >
+        <option
+          v-for="option in options"
+          :key="option.value"
+          :value="option.value"
+        >
+          {{ option.label }}
+        </option>
+      </select>
+      <p class="av-multiselect__caption">
+        {{ modelValue.length
+          ? (selectedText || modelValue.length + ' sélection(s)')
+          : placeholder
+        }}
+      </p>
+    </div>
+  `
+})

--- a/src/components/interaction/selects/AvMultiselect/AvMultiselect.test.ts
+++ b/src/components/interaction/selects/AvMultiselect/AvMultiselect.test.ts
@@ -1,3 +1,4 @@
+import type { AvMultiselectOption } from '@/components/interaction/selects/AvMultiselect/AvMultiselect.types'
 import { flushPromises, mount, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, expect } from 'vitest'
 import { nextTick } from 'vue'
@@ -5,19 +6,6 @@ import { AvCheckboxStub } from '@/components/interaction/checkboxes/AvCheckbox/A
 import AvMultiselect, { type AvMultiselectProps } from '@/components/interaction/selects/AvMultiselect/AvMultiselect.vue'
 import { AvButtonStub } from '@/tests'
 import { BddTest } from '@/tests/utils'
-
-const doExpandSpy = vi.fn()
-const onTransitionEndSpy = vi.fn()
-
-vi.mock('@/composables/use-collapsable/use-collapsable', () => ({
-  useCollapsable: () => ({
-    collapse: ref(),
-    collapsing: ref(false),
-    cssExpanded: ref(false),
-    doExpand: doExpandSpy,
-    onTransitionEnd: onTransitionEndSpy,
-  }),
-}))
 
 interface VmType {
   handleKeyDownEscape: (e: KeyboardEvent) => void
@@ -34,10 +22,11 @@ const defaultProps = {
   label: 'Choisissez des options',
   placeholder: 'Sélectionnez une option',
   options: defaultOptions,
-  selectAll: false
+  selectAll: false,
+  selectedText: 'Options sélectionnées'
 }
 
-function mountWithProps (props: Partial<AvMultiselectProps> = {}, attrs: Record<string, unknown> = {}) {
+function mountWithProps (props: Partial<AvMultiselectProps & { modelValue: AvMultiselectOption[] }> = {}, attrs: Record<string, unknown> = {}) {
   return mount(AvMultiselect, {
     props: { ...defaultProps, ...props },
     attrs: { ...attrs },
@@ -80,7 +69,6 @@ BddTest().given('an AvMultiselect component', () => {
         })
 
         BddTest().then('it should call clean', () => {
-          expect(removeSpy).toHaveBeenCalledWith('click', expect.any(Function))
           expect(removeSpy).toHaveBeenCalledWith('keydown', expect.any(Function))
         })
       })
@@ -92,7 +80,6 @@ BddTest().given('an AvMultiselect component', () => {
       })
 
       BddTest().then('it should remove the event listeners', () => {
-        expect(removeSpy).toHaveBeenCalledWith('click', expect.any(Function))
         expect(removeSpy).toHaveBeenCalledWith('keydown', expect.any(Function))
       })
     })
@@ -104,7 +91,7 @@ BddTest().given('an AvMultiselect component', () => {
       })
 
       BddTest().then('the collapse should be visible', () => {
-        const collapse = wrapper.find('.av-collapse')
+        const collapse = wrapper.find('[data-testid="av-multiselect__collapse"]')
         expect(collapse.exists()).toBe(true)
         expect(collapse.isVisible()).toBe(true)
       })
@@ -135,7 +122,7 @@ BddTest().given('an AvMultiselect component', () => {
 
     BddTest().then('it should render in selected state with correct text', () => {
       const button = wrapper.find('button.av-multiselect')
-      expect(button.text()).toContain('1 option sélectionnée')
+      expect(button.text()).toBe(defaultProps.selectedText)
       expect(button.classes()).toContain('av-multiselect--selected')
     })
   })
@@ -149,7 +136,7 @@ BddTest().given('an AvMultiselect component', () => {
 
     BddTest().then('it should render in selected state with plural text', () => {
       const button = wrapper.find('button.av-multiselect')
-      expect(button.text()).toContain('2 options sélectionnées')
+      expect(button.text()).toBe(defaultProps.selectedText)
     })
   })
 

--- a/src/components/interaction/selects/AvMultiselect/AvMultiselect.vue
+++ b/src/components/interaction/selects/AvMultiselect/AvMultiselect.vue
@@ -2,7 +2,6 @@
 import type AvButton from '@/components/interaction/buttons/AvButton/AvButton.vue'
 import type { AvMultiselectOption } from '@/components/interaction/selects/AvMultiselect/AvMultiselect.types'
 import MultiselectCollapse from '@/components/interaction/selects/AvMultiselect/components/MultiselectCollapse.vue'
-import { useCollapsable } from '@/composables/use-collapsable/use-collapsable'
 import { ICONS_DATA_URL } from '@/tokens'
 
 export interface AvMultiselectProps {
@@ -28,11 +27,6 @@ export interface AvMultiselectProps {
    * @default 'Utilisez la tabulation (ou les touches flèches) pour naviguer dans la liste des suggestions'
    */
   collapseHint?: string
-
-  /**
-   * Selected option(s) value(s).
-   */
-  modelValue: AvMultiselectOption[]
 
   /**
    * Select text label.
@@ -82,7 +76,7 @@ export interface AvMultiselectProps {
   /**
    * Displayed text when options are selected.
    */
-  selectedText?: string
+  selectedText: string
 
   /**
    * Displays the select all items button
@@ -102,13 +96,6 @@ export interface AvMultiselectProps {
   search?: boolean
 
   /**
-   * Label (legend) for the multiselect, rendered visually as a title.
-   * Helps screen readers understand the select context.
-   * @default ''
-   */
-  legend?: string
-
-  /**
    * Fixes the width of the multiselect
    */
   width?: string
@@ -117,6 +104,11 @@ export interface AvMultiselectProps {
    * Fixes the height of the multiselect
    */
   height?: string
+
+  /**
+   * Max height of the collapse list of options.
+   */
+  collapseMaxHeight?: string
 }
 
 const {
@@ -124,7 +116,6 @@ const {
   id,
   hint = '',
   collapseHint = 'Utilisez la tabulation (ou les touches flèches) pour naviguer dans la liste des suggestions',
-  modelValue,
   label,
   labelVisible = true,
   labelClass = '',
@@ -137,26 +128,16 @@ const {
   selectAll = false,
   selectAllLabel = ['Tout sélectionner', 'Tout désélectionner'],
   search = false,
-  legend = '',
   width,
-  height
+  height,
+  collapseMaxHeight,
 } = defineProps<AvMultiselectProps>()
 
-/**
- * Events emitted by the component.
- */
-const emit = defineEmits<{
-  /**
-   * Emitted when an option is selected or unselected.
-   * @param value Values (`AvMultiselectOption[]`) of the current selected options.
-   */
-  (e: 'update:modelValue', value: AvMultiselectOption[]): void
-}>()
+const modelValue = defineModel<AvMultiselectOption[]>({ default: [] })
 
 const realId = computed(() => id ?? `multi-select-${crypto.randomUUID()}`)
 
 const host = ref<InstanceType<typeof AvButton> | null>(null)
-const expanded = ref(false)
 
 const message = computed(() => {
   return errorMessage || successMessage
@@ -165,35 +146,14 @@ const messageType = computed(() => {
   return errorMessage ? 'error' : 'success'
 })
 
-const {
-  collapse,
-  collapsing,
-  cssExpanded,
-  doExpand,
-  onTransitionEnd,
-} = useCollapsable()
-
-const useCollapsableReturn = {
-  collapse,
-  collapsing,
-  cssExpanded,
-  doExpand,
-  onTransitionEnd,
-}
-
-const computedModelValue = computed(() => modelValue.map(selected => selected.value))
+const computedModelValue = computed(() => modelValue.value.map(selected => selected.value))
 
 const title = computed(() => {
-  if (!modelValue || modelValue.length === 0) {
+  if (modelValue.value.length === 0) {
     return placeholder
   }
 
-  if (selectedText) {
-    return selectedText
-  }
-
-  const pluralChoice = modelValue.length > 1 ? 's' : ''
-  return `${modelValue.length} option${pluralChoice} sélectionnée${pluralChoice}`
+  return selectedText
 })
 
 const isVisible = ref(false)
@@ -204,29 +164,13 @@ function handleKeyDownEscape (event: KeyboardEvent) {
   }
 }
 
-function handleClickOutside (event: MouseEvent) {
-  const element = event.target as HTMLElement
-  if (!host.value?.$el.contains(element) && !collapse.value?.contains(element)) {
-    close()
-  }
-}
-
 function open () {
-  expanded.value = true
   isVisible.value = true
-  document.addEventListener('click', handleClickOutside)
   document.addEventListener('keydown', handleKeyDownEscape)
-  setTimeout(() => {
-    doExpand(true)
-  }, 100)
 }
 
 function close () {
-  expanded.value = false
-  doExpand(false)
-  setTimeout(() => {
-    isVisible.value = false
-  }, 300)
+  isVisible.value = false
   clean()
 }
 
@@ -240,15 +184,7 @@ async function handleClick () {
 }
 
 function clean () {
-  document.removeEventListener('click', handleClickOutside)
   document.removeEventListener('keydown', handleKeyDownEscape)
-}
-
-function handleFocusPreviousElement (event: KeyboardEvent) {
-  const currentElement = document.activeElement as HTMLElement
-  if (event.shiftKey && currentElement === host.value?.$el) {
-    close()
-  }
 }
 
 function onUpdateModelValue (values: (string | number)[]) {
@@ -256,7 +192,7 @@ function onUpdateModelValue (values: (string | number)[]) {
     values.includes(option.value)
   ) ?? []
 
-  emit('update:modelValue', selectedOptions)
+  modelValue.value = selectedOptions
 }
 
 onUnmounted(() => {
@@ -307,10 +243,10 @@ const styleVars = computed(() => ({
       :label="title"
       class="av-multiselect"
       :disabled="disabled"
-      :aria-expanded="expanded"
+      :aria-expanded="isVisible"
       :aria-controls="`${realId}-collapse`"
       :class="{
-        'av-multiselect--is-open': expanded,
+        'av-multiselect--is-open': isVisible,
         'av-multiselect--dense': dense,
         'av-multiselect--unselected': modelValue.length === 0,
         'av-multiselect--selected': modelValue.length > 0,
@@ -318,20 +254,18 @@ const styleVars = computed(() => ({
       :small="dense"
       :style="styleVars"
       @click="handleClick"
-      @keydown.shift.tab="handleFocusPreviousElement"
     />
     <MultiselectCollapse
       :id="realId"
-      :legend="legend"
+      v-model="computedModelValue"
       :hint="collapseHint"
-      :model-value="computedModelValue"
       :is-visible="isVisible"
       :select-all="selectAll"
       :select-all-label="selectAllLabel"
       :search="search"
       :options="options"
       :selected="modelValue"
-      :use-collapsable-return="useCollapsableReturn"
+      :max-height="collapseMaxHeight"
       @close="close"
       @update:model-value="onUpdateModelValue"
     />

--- a/src/components/interaction/selects/AvMultiselect/components/MultiselectCollapse.test.ts
+++ b/src/components/interaction/selects/AvMultiselect/components/MultiselectCollapse.test.ts
@@ -1,5 +1,6 @@
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, expect, vi } from 'vitest'
+import { nextTick } from 'vue'
 import { AvFieldsetStub } from '@/components/base/AvFieldset/AvFieldset.stub'
 import { AvCheckboxStub } from '@/components/interaction/checkboxes/AvCheckbox/AvCheckbox.stub'
 import MultiselectCollapse, { type MultiselectCollapseProps } from '@/components/interaction/selects/AvMultiselect/components/MultiselectCollapse.vue'
@@ -17,13 +18,6 @@ const defaultProps: MultiselectCollapseProps = {
   selected: [],
   options: defaultOptions,
   id: 'test-collapse',
-  useCollapsableReturn: {
-    collapse: ref(undefined),
-    collapsing: ref(false),
-    cssExpanded: ref(false),
-    doExpand: vi.fn(),
-    onTransitionEnd: vi.fn()
-  }
 }
 
 function mountWithProps (props: Partial<MultiselectCollapseProps> = {}):
@@ -44,6 +38,7 @@ VueWrapper<InstanceType<typeof MultiselectCollapse>> {
 
 BddTest().given('a MultiselectCollapse component', () => {
   let wrapper: VueWrapper<InstanceType<typeof MultiselectCollapse>>
+  const addSpy = vi.spyOn(document, 'addEventListener')
   const removeSpy = vi.spyOn(document, 'removeEventListener')
 
   BddTest().and('default props', () => {
@@ -89,17 +84,6 @@ BddTest().given('a MultiselectCollapse component', () => {
           expect(checkboxes[0].props('label')).toBe('Option 2')
         })
       })
-
-      BddTest().and('keyboard escape pressed', () => {
-        beforeEach(() => {
-          const vm = wrapper.vm as unknown as { handleKeyDownEscape: (e: KeyboardEvent) => void }
-          vm.handleKeyDownEscape({ key: 'Escape' } as KeyboardEvent)
-        })
-
-        BddTest().then('it should emit close', () => {
-          expect(wrapper.emitted('close')).toBeTruthy()
-        })
-      })
     })
 
     BddTest().when('no results for search', () => {
@@ -121,72 +105,6 @@ BddTest().given('a MultiselectCollapse component', () => {
 
       BddTest().then('it should call clean', () => {
         expect(removeSpy).toHaveBeenCalledWith('click', expect.any(Function))
-        expect(removeSpy).toHaveBeenCalledWith('keydown', expect.any(Function))
-      })
-    })
-
-    BddTest().when('focusing the first checkbox', () => {
-      beforeEach(() => {
-        const event = new KeyboardEvent('keydown')
-        const vm = wrapper.vm as unknown as { handleFocusFirstCheckbox: (e: KeyboardEvent) => void }
-        vm.handleFocusFirstCheckbox(event)
-      })
-
-      BddTest().then('the first checkbox should be focused', () => {
-        const checkboxes = wrapper.findAll('input[type="checkbox"]')
-        expect(document.activeElement).toStrictEqual(checkboxes[0].element)
-      })
-    })
-
-    BddTest().when('pressing arrow down to focus next checkbox', () => {
-      beforeEach(() => {
-        const checkboxes = wrapper.findAll('input[type="checkbox"]')
-        const checkboxEl = checkboxes[0].element as HTMLElement
-        checkboxEl.focus()
-        const event = new KeyboardEvent('keydown')
-        const vm = wrapper.vm as unknown as { handleFocusNextCheckbox: (e: KeyboardEvent) => void }
-        vm.handleFocusNextCheckbox(event)
-      })
-
-      BddTest().then('the second checkbox should be focused', () => {
-        const checkboxes = wrapper.findAll('input[type="checkbox"]')
-        expect(document.activeElement).toBe(checkboxes[1].element)
-      })
-    })
-
-    BddTest().when('pressing arrow up to focus previous checkbox', () => {
-      beforeEach(() => {
-        const checkboxes = wrapper.findAll('input[type="checkbox"]')
-        const checkboxEl = checkboxes[0].element as HTMLElement
-        checkboxEl.focus()
-        const event = new KeyboardEvent('keydown')
-        const vm = wrapper.vm as unknown as { handleFocusPreviousCheckbox: (e: KeyboardEvent) => void }
-        vm.handleFocusPreviousCheckbox(event)
-      })
-
-      BddTest().then('the last checkbox should be focused (wrap around)', () => {
-        const checkboxes = wrapper.findAll('input[type="checkbox"]')
-        expect(document.activeElement).toStrictEqual(checkboxes[checkboxes.length - 1].element)
-      })
-    })
-
-    BddTest().when('tab is pressed on the last checkbox', () => {
-      beforeEach(() => {
-        const vm = wrapper.vm as unknown as {
-          handleFocusNextElementUsingTab: (e: KeyboardEvent) => void
-          host: { value: unknown }
-        }
-        vm.host = { value: wrapper.element }
-
-        const checkboxes = wrapper.findAll('input[type="checkbox"]')
-        const checkboxEl = checkboxes[checkboxes.length - 1].element as HTMLElement
-        checkboxEl.focus()
-        const event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: false })
-        vm.handleFocusNextElementUsingTab(event)
-      })
-
-      BddTest().then('it should emit close', () => {
-        expect(wrapper.emitted('close')).toBeTruthy()
       })
     })
 
@@ -198,6 +116,120 @@ BddTest().given('a MultiselectCollapse component', () => {
       BddTest().then('isAllSelected should be true', () => {
         const vm = wrapper.vm as unknown as { isAllSelected: boolean }
         expect(vm.isAllSelected).toBe(true)
+      })
+    })
+  })
+
+  BddTest().and('isVisible is false', () => {
+    beforeEach(() => {
+      wrapper = mountWithProps({ isVisible: false })
+    })
+
+    BddTest().when('isVisible changes to true', () => {
+      beforeEach(async () => {
+        await wrapper.setProps({ isVisible: true })
+        await nextTick()
+      })
+
+      BddTest().then('it should add a click event listener on document', () => {
+        expect(addSpy).toHaveBeenCalledWith('click', expect.any(Function))
+      })
+    })
+
+    BddTest().when('isVisible changes from true to false', () => {
+      beforeEach(async () => {
+        await wrapper.setProps({ isVisible: true })
+        await nextTick()
+        await wrapper.setProps({ isVisible: false })
+      })
+
+      BddTest().then('it should remove the click event listener from document', () => {
+        expect(removeSpy).toHaveBeenCalledWith('click', expect.any(Function))
+      })
+    })
+  })
+
+  BddTest().when('the user clicks outside the component', () => {
+    let capturedHandler: ((e: MouseEvent) => void) | undefined
+
+    beforeEach(async () => {
+      vi.spyOn(document, 'addEventListener').mockImplementation((type, listener) => {
+        if (type === 'click') {
+          capturedHandler = listener as (e: MouseEvent) => void
+        }
+      })
+      wrapper = mountWithProps({ isVisible: false })
+      await wrapper.setProps({ isVisible: true })
+      await nextTick()
+    })
+
+    BddTest().then('it should emit close', () => {
+      const outsideEl = document.createElement('div')
+      document.body.appendChild(outsideEl)
+      capturedHandler!(new MouseEvent('click', { bubbles: true }) as MouseEvent)
+      Object.defineProperty(MouseEvent.prototype, 'target', { value: outsideEl, configurable: true })
+      const event = new MouseEvent('click', { bubbles: true })
+      capturedHandler!(event)
+      expect(wrapper.emitted('close')).toBeTruthy()
+      outsideEl.remove()
+    })
+
+    BddTest().when('the click target is inside the collapse element', () => {
+      BddTest().then('it should not emit close', () => {
+        const collapseEl = wrapper.find(`#test-collapse-collapse`)
+        const insideEl = document.createElement('span')
+        collapseEl.element.appendChild(insideEl)
+
+        const event = Object.assign(new MouseEvent('click', { bubbles: true }), {})
+        Object.defineProperty(event, 'target', { value: insideEl, configurable: true })
+        capturedHandler!(event)
+
+        expect(wrapper.emitted('close')).toBeFalsy()
+        insideEl.remove()
+      })
+    })
+  })
+
+  BddTest().when('the user clicks inside the component', () => {
+    let capturedHandler: ((e: MouseEvent) => void) | undefined
+
+    beforeEach(async () => {
+      vi.spyOn(document, 'addEventListener').mockImplementation((type, listener) => {
+        if (type === 'click') {
+          capturedHandler = listener as (e: MouseEvent) => void
+        }
+      })
+      wrapper = mountWithProps({ isVisible: false })
+      await wrapper.setProps({ isVisible: true })
+      await nextTick()
+    })
+
+    BddTest().then('it should not emit close', () => {
+      const collapseEl = wrapper.find(`#test-collapse-collapse`)
+      const insideEl = document.createElement('span')
+      collapseEl.element.appendChild(insideEl)
+
+      const event = Object.assign(new MouseEvent('click', { bubbles: true }), {})
+      Object.defineProperty(event, 'target', { value: insideEl, configurable: true })
+      capturedHandler!(event)
+
+      expect(wrapper.emitted('close')).toBeFalsy()
+      insideEl.remove()
+    })
+
+    BddTest().and('skipNextClickOutside is true (first click after becoming visible)', () => {
+      BddTest().then('it should not emit close and clear the flag', () => {
+        const outsideEl = document.createElement('div')
+        document.body.appendChild(outsideEl)
+        const event = Object.assign(new MouseEvent('click', { bubbles: true }), {})
+        Object.defineProperty(event, 'target', { value: outsideEl, configurable: true })
+
+        capturedHandler!(event)
+        expect(wrapper.emitted('close')).toBeFalsy()
+
+        capturedHandler!(event)
+        expect(wrapper.emitted('close')).toBeTruthy()
+        outsideEl.remove()
       })
     })
   })

--- a/src/components/interaction/selects/AvMultiselect/components/MultiselectCollapse.vue
+++ b/src/components/interaction/selects/AvMultiselect/components/MultiselectCollapse.vue
@@ -1,9 +1,7 @@
 <script lang="ts" setup>
 import type AvButton from '@/components/interaction/buttons/AvButton/AvButton.vue'
 import type { AvMultiselectOption } from '@/components/interaction/selects/AvMultiselect/AvMultiselect.types'
-import type { UseCollapsableReturn } from '@/composables/use-collapsable/use-collapsable'
-import AvCheckbox from '@/components/interaction/checkboxes/AvCheckbox/AvCheckbox.vue'
-import AvCheckboxesGroup from '@/components/interaction/checkboxes/AvCheckboxesGroup/AvCheckboxesGroup.vue'
+import { nextTick } from 'vue'
 import { MDI_ICONS } from '@/tokens/icons'
 
 export interface MultiselectCollapseProps {
@@ -11,27 +9,25 @@ export interface MultiselectCollapseProps {
   selected: AvMultiselectOption[]
   options: AvMultiselectOption[]
   hint?: string
-  legend?: string
   id: string
   selectAll?: boolean
   search?: boolean
   selectAllLabel?: [string, string]
-  useCollapsableReturn: Omit<UseCollapsableReturn, 'adjust'>
   noResultLabel?: string
+  maxHeight?: string
 }
 
 const {
   isVisible,
   hint = 'Utilisez la tabulation (ou les touches flèches) pour naviguer dans la liste des suggestions',
-  legend = '',
   selectAll = false,
   selectAllLabel = ['Tout sélectionner', 'Tout désélectionner'],
   search = false,
   id,
   options,
   selected,
-  useCollapsableReturn,
-  noResultLabel = 'Pas de résultat'
+  noResultLabel = 'Pas de résultat',
+  maxHeight,
 } = defineProps<MultiselectCollapseProps>()
 
 /**
@@ -52,48 +48,45 @@ function generateId (option: AvMultiselectOption, id: string): string {
 }
 
 const host = ref<InstanceType<typeof AvButton> | null>(null)
-const expanded = ref(false)
+const collapse = ref<HTMLElement | null>(null)
+let skipNextClickOutside = false
 const model = defineModel<(string | number)[]>({ required: true })
 const hostWidth = ref(0)
 
-const observations: (() => void)[] = []
-
-const {
-  collapse,
-  collapsing,
-  cssExpanded,
-  onTransitionEnd,
-} = useCollapsableReturn
-
-function getAllCheckbox (): NodeListOf<HTMLElement> {
-  return document.querySelectorAll(`[id^="${id}-"][id$="-checkbox"]`)
-}
-
 const searchInput = ref('')
 
-function handleKeyDownEscape (event: KeyboardEvent) {
-  if (event.key === 'Escape') {
-    emit('close')
-  }
-}
-
 function handleClickOutside (event: MouseEvent) {
-  const element = event.target as HTMLElement
-  if (!host.value?.$el.contains(element) && !collapse.value?.contains(element)) {
-    emit('close')
+  if (skipNextClickOutside) {
+    skipNextClickOutside = false
+    return
   }
+  const element = event.target as HTMLElement
+  const hostEl = host.value && (host.value as any).$el ? (host.value as any).$el : null
+  const collapseEl = collapse.value
+  if (hostEl && hostEl.contains(element)) {
+    return
+  }
+  if (collapseEl && collapseEl.contains(element)) {
+    return
+  }
+  emit('close')
 }
 
 function clean () {
-  while (observations.length) {
-    const observation = observations.pop()
-    if (observation) {
-      observation()
-    }
-  }
   document.removeEventListener('click', handleClickOutside)
-  document.removeEventListener('keydown', handleKeyDownEscape)
 }
+
+watch(() => isVisible, (visible) => {
+  if (visible) {
+    nextTick(() => {
+      skipNextClickOutside = true
+      document.addEventListener('click', handleClickOutside)
+    })
+  }
+  else {
+    clean()
+  }
+})
 
 const filteredOptions = computed(() =>
   options.filter((option) => {
@@ -133,55 +126,6 @@ function handleClickSelectAllClick () {
   model.value = Array.from(modelSet)
 }
 
-function handleFocusFirstCheckbox (event: KeyboardEvent) {
-  const [firstCheckbox] = getAllCheckbox()
-  if (firstCheckbox) {
-    event.preventDefault()
-    firstCheckbox.focus()
-  }
-}
-
-function handleFocusNextCheckbox (event: KeyboardEvent) {
-  event.preventDefault()
-  const checkboxes = getAllCheckbox()
-  const activeElement = document.activeElement as HTMLElement
-  const currentIndex = Array.from(checkboxes).indexOf(activeElement)
-
-  if (currentIndex !== -1) {
-    const nextIndex = (currentIndex + 1) % checkboxes.length
-    checkboxes[nextIndex].focus()
-  }
-}
-
-function handleFocusPreviousCheckbox (event: KeyboardEvent) {
-  event.preventDefault()
-  const checkboxes = getAllCheckbox()
-  const activeElement = document.activeElement as HTMLElement
-  const currentIndex = Array.from(checkboxes).indexOf(activeElement)
-
-  if (currentIndex !== -1) {
-    const previousIndex
-      = (currentIndex - 1 + checkboxes.length) % checkboxes.length
-    checkboxes[previousIndex].focus()
-  }
-}
-
-function handleFocusNextElementUsingTab (event: KeyboardEvent) {
-  const checkboxes = getAllCheckbox()
-  const activeElement = document.activeElement as HTMLElement
-  const currentIndex = Array.from(checkboxes).indexOf(activeElement)
-  if (currentIndex + 1 === checkboxes.length && host.value && !event.shiftKey) {
-    emit('close')
-  }
-}
-
-function handleFocusPreviousElement (event: KeyboardEvent) {
-  const currentElement = document.activeElement as HTMLElement
-  if (event.shiftKey && currentElement === host.value?.$el) {
-    emit('close')
-  }
-}
-
 onUnmounted(() => {
   clean()
 })
@@ -195,9 +139,8 @@ onUnmounted(() => {
     :style="{
       '--width-host': `${hostWidth}px`,
     }"
-    class="av-multiselect__collapse av-collapse av-p-xs av-ml-xxs"
-    :class="{ 'av-collapse--expanded': cssExpanded, 'av-collapsing': collapsing }"
-    @transitionend="onTransitionEnd(expanded)"
+    class="av-multiselect__collapse"
+    data-testid="av-multiselect__collapse"
   >
     <p
       :id="`${id}-text-hint`"
@@ -217,7 +160,6 @@ onUnmounted(() => {
           :label="selectAllLabel[isAllSelected ? 1 : 0]"
           :icon="isAllSelected ? MDI_ICONS.CLOSE_CIRCLE_OUTLINE : MDI_ICONS.CHECK_CIRCLE_OUTLINE"
           @click="handleClickSelectAllClick"
-          @keydown.shift.tab="handleFocusPreviousElement"
         />
       </li>
     </ul>
@@ -230,33 +172,27 @@ onUnmounted(() => {
         aria-live="polite"
         placeholder="Rechercher"
         type="search"
-        @keydown.down="handleFocusFirstCheckbox"
-        @keydown.right="handleFocusFirstCheckbox"
-        @keydown.tab="handleFocusPreviousElement"
       />
     </div>
-    <AvCheckboxesGroup
-      :id="`${id}-checkboxes`"
-      class="av-multiselect__collapse__fieldset"
-      :legend="legend"
-      :legend-id="`${id}-checkboxes-legend`"
+    <AvList
+      background-color="var(--dialog)"
+      bordered
+      border-color="var(--stroke)"
+      border-radius="var(--radius-lg)"
+      size="xsmall"
+      class="multiselect-collapse-options-list"
     >
-      <AvCheckbox
+      <AvCheckboxListItem
         v-for="option in filteredOptions"
-        :id="`${generateId(option, id)}-checkbox`"
+        :id="option.value.toString()"
         :key="`${generateId(option, id)}-fieldset`"
         v-model="model"
-        :value="option.value"
+        list-id="multiselect-collapse-options-list"
+        :aria-label="option.label"
         :label="option.label"
         :icon="option.icon"
-        :name="`${generateId(option, id)}-checkbox`"
-        @keydown.down="handleFocusNextCheckbox"
-        @keydown.right="handleFocusNextCheckbox"
-        @keydown.up="handleFocusPreviousCheckbox"
-        @keydown.left="handleFocusPreviousCheckbox"
-        @keydown.tab="handleFocusNextElementUsingTab"
       />
-    </AvCheckboxesGroup>
+    </AvList>
     <div v-if="filteredOptions.length === 0">
       {{ noResultLabel }}
     </div>
@@ -274,6 +210,14 @@ onUnmounted(() => {
 
   &__fieldset {
     overflow: auto;
+    max-height: v-bind('maxHeight');
   }
+}
+
+.multiselect-collapse-options-list {
+  max-height: v-bind('maxHeight');
+  overflow-y: auto;
+  overflow-x: hidden;
+  border: none;
 }
 </style>

--- a/src/tests/index.ts
+++ b/src/tests/index.ts
@@ -16,6 +16,7 @@ import { AvListStub } from '@/components/interaction/lists/AvList/AvList.stub'
 import { AvListItemStub } from '@/components/interaction/lists/AvListItem/AvListItem.stub'
 import { AvTagPickerStub } from '@/components/interaction/pickers/AvTagPicker/AvTagPicker.stub'
 import { AvAutocompleteStub } from '@/components/interaction/selects/AvAutocomplete/AvAutocomplete.stub'
+import { AvMultiselectStub } from '@/components/interaction/selects/AvMultiselect/AvMultiselect.stub'
 import { AvSelectStub } from '@/components/interaction/selects/AvSelect/AvSelect.stub'
 import { AvTabStub } from '@/components/interaction/tabs/AvTab/AvTab.stub'
 import { AvTabsStub } from '@/components/interaction/tabs/AvTabs/AvTabs.stub'
@@ -50,6 +51,7 @@ export {
   AvListItemStub,
   AvListStub,
   AvModalStub,
+  AvMultiselectStub,
   AvPaginationStub,
   AvPeriodInputStub,
   AvPopoverStub,


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR fixes visual jump issues in the `MultiselectCollapse` component when opening/closing the multiselect dropdown, and adds scroll-following-focus behavior so that focused options remain visible within a constrained-height list.

**Main changes:**
- 🐛 Refactors `MultiselectCollapse` to prevent layout jumps during collapse animation
- ♿️ Adds `scrollIntoView` on focus in `AvCheckboxListItem` so keyboard navigation keeps focused option visible in a max-height list
- ✨ Adds `collapseMaxHeight` prop to `AvMultiselect` to allow constraining the dropdown list height
- ♻️ Migrates `AvMultiselect` model binding from `modelValue` prop + event to `defineModel`
- 🔥 Removes unused `legend` prop and `useCollapsable` import from `AvMultiselect`
- ✅ Updates unit and a11y tests to reflect new structure
- 📝 Updates `AvMultiselect.md` documentation (new prop, model events section)
- 🍱 Adds `AvMultiselectStub` and exports it in the test barrel
- 📖 Adds `CollapseMaxHeight` Storybook story

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1299

---

### Documentation
- `AvMultiselect.md` updated: added `collapseMaxHeight` prop, replaced `update:modelValue` event table with `defineModel` section, removed `modelValue` row
- `AvMultiselect.stories.ts`: new `CollapseMaxHeight` story demonstrating the max-height constraint and keyboard scrolling

**Modified files:**
- `a11y/tests/interaction/selects/AvMultiselect.a11y.test.ts` — add `CollapseMaxHeight` story to a11y suite
- `src/components/interaction/lists/AvCheckboxListItem/AvCheckboxListItem.vue` — add `scrollIntoView` on focus
- `src/components/interaction/selects/AvMultiselect/AvMultiselect.md` — doc update
- `src/components/interaction/selects/AvMultiselect/AvMultiselect.stories.ts` — add `CollapseMaxHeight` story
- `src/components/interaction/selects/AvMultiselect/AvMultiselect.stub.ts` — new stub
- `src/components/interaction/selects/AvMultiselect/AvMultiselect.test.ts` — remove `useCollapsable` mock, adapt assertions
- `src/components/interaction/selects/AvMultiselect/AvMultiselect.vue` — `defineModel` migration, remove `legend`, `collapseMaxHeight` prop
- `src/components/interaction/selects/AvMultiselect/components/MultiselectCollapse.test.ts` — updated tests
- `src/components/interaction/selects/AvMultiselect/components/MultiselectCollapse.vue` — prevent jumps, height management
- `src/tests/index.ts` — export `AvMultiselectStub`

---

### Target Branch
`develop`

---

### Additional Notes
The jump issue was caused by the collapse animation conflicting with the dynamic height of the list. The fix makes the height management explicit via `collapseMaxHeight` and ensures the animation does not cause layout recalculations.

The `defineModel` migration aligns `AvMultiselect` with the rest of the component library and removes the need for the explicit `modelValue` prop.

---

### Known Limitations or Side Effects
Consumers that used the `legend` prop or bound `modelValue` explicitly must migrate to `defineModel` (`v-model`). The `selectedText` prop is now required.

---

## ✅ Checklist

- [ ] a11y tested (`CollapseMaxHeight` story added to a11y suite)
- [ ] Tests provided (unit tests updated for `AvMultiselect` and `MultiselectCollapse`)
- [ ] i18n handled (no new text literals added)
- [ ] Performance tests (no significant performance changes)
- [ ] No unnecessary code (removed unused `legend` prop and `useCollapsable` mock)
- [ ] Code style and formatting rules respected (linting conventions followed)
- [ ] Semantic Versioning respected (conventional commits used)
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process (no database changes; component API change documented above)
