### PR TITLE
fix(1280): remove AvAutocomplete scrollbar overrides

### DIFF
--- a/src/components/interaction/selects/AvAutocomplete/AvAutocomplete.vue
+++ b/src/components/interaction/selects/AvAutocomplete/AvAutocomplete.vue
@@ -15,7 +15,6 @@ const props = withDefaults(defineProps<AvAutocompleteProps<T>>(), {
     size: 'small',
     ariaLabel: 'Available options list'
   }),
-  scrollbarClass: 'av-autocomplete__scrollbar--default',
   dropdownClass: 'av-autocomplete__dropdown--default',
   loading: false,
   debounceDelay: 300,

--- a/src/components/interaction/selects/AvAutocomplete/AvAutocompleteDropdown.vue
+++ b/src/components/interaction/selects/AvAutocomplete/AvAutocompleteDropdown.vue
@@ -222,24 +222,6 @@ defineExpose({
 .av-autocomplete-dropdown__options {
   max-height: inherit;
   overflow-y: auto;
-  scrollbar-width: thin;
-
-  &::-webkit-scrollbar {
-    width: 0.375rem;
-  }
-
-  &::-webkit-scrollbar-track {
-    background: transparent;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background-color: var(--divider);
-    border-radius: var(--radius-sm);
-  }
-
-  &::-webkit-scrollbar-thumb:hover {
-    background-color: var(--text2);
-  }
 }
 
 .av-autocomplete-dropdown__empty {
@@ -254,29 +236,5 @@ defineExpose({
 .av-autocomplete-dropdown__loading-text {
   font-size: 0.875rem;
   font-weight: 400;
-}
-</style>
-
-<style lang="scss">
-.av-autocomplete__scrollbar--default {
-  scrollbar-color: var(--light-foreground-primary1) var(--light-background-primary1);
-
-  &::-webkit-scrollbar {
-    width: 0.375rem;
-  }
-
-  &::-webkit-scrollbar-track {
-    background: var(--light-background-primary1);
-    border-radius: var(--radius-sm);
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background-color: var(--light-foreground-primary1);
-    border-radius: var(--radius-sm);
-  }
-
-  &::-webkit-scrollbar-thumb:hover {
-    background-color: var(--dark-background-primary1);
-  }
 }
 </style>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
- Remove custom scrollbar style overrides from `AvAutocomplete` and `AvAutocompleteDropdown` components, restoring default browser scrollbar behaviour

---

### Reference to an Issue, Feature, Task, User Story or another PR
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1280

---

**Modified areas:**
- `src/components/interaction/selects/AvAutocomplete/AvAutocomplete.vue`
- `src/components/interaction/selects/AvAutocomplete/AvAutocompleteDropdown.vue`

---

### Target Branch
`develop`

---

### Additional Notes
- No other component override the default scrollbar

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process