### PR TITLE
feat(1548): AvModal - add clickOutside event

### DIFF
--- a/src/components/overlay/modals/AvModal/AvModal.md
+++ b/src/components/overlay/modals/AvModal/AvModal.md
@@ -35,7 +35,8 @@ It consists of the following elements:
 | Name | Data (*payload*) | Description |
 | --- | --- | --- |
 | `‘close’` | | Event emitted when modal is closed. |
-| `‘close’` | | Event emitted when confirm button is clicked. |
+| `‘confirm’` | | Event emitted when confirm button is clicked. |
+| `‘clickOutside’` | | Event emitted when a click is detected outside the modal. |
 
 ## 🎨 Slots
 

--- a/src/components/overlay/modals/AvModal/AvModal.stories.ts
+++ b/src/components/overlay/modals/AvModal/AvModal.stories.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-alert */
 import type { Meta, StoryFn } from '@storybook/vue3'
 import AvIconText from '@/components/base/AvIconText/AvIconText.vue'
 import AvButton from '@/components/interaction/buttons/AvButton/AvButton.vue'
@@ -75,12 +76,13 @@ export default meta
 const Template: StoryFn<AvModalProps> = args => ({
   components: { AvModal, AvIconText, AvButton },
   setup () {
+    const onClickOutside = () => alert('Clicked outside!')
     const show = ref(args.opened)
-    return { args, show }
+    return { args, show, onClickOutside }
   },
   template: `
     <button @click="show = true">Open modal</button>
-    <AvModal v-bind="args" :opened="show" @close="show = false">
+    <AvModal v-bind="args" :opened="show" @close="show = false" @clickOutside="onClickOutside">
       <template #header>
         <AvIconText
           icon="mdi:swap-horizontal"

--- a/src/components/overlay/modals/AvModal/AvModal.stub.ts
+++ b/src/components/overlay/modals/AvModal/AvModal.stub.ts
@@ -8,7 +8,7 @@ export const AvModalStub = defineComponent({
     'isLoading',
     'confirmButtonDisabled'
   ],
-  emits: ['close', 'confirm'],
+  emits: ['close', 'confirm', 'clickOutside'],
   template: `
     <div class="av-modal">
       <slot name="header"></slot>

--- a/src/components/overlay/modals/AvModal/AvModal.vue
+++ b/src/components/overlay/modals/AvModal/AvModal.vue
@@ -87,10 +87,12 @@ const {
  *
  * @event close - Event emitted when the modal is closed.
  * @event confirm - Event emitted when the confirm button is clicked.
+ * @event clickOutside - Event emitted when the user clicks outside the modal content.
  */
 const emit = defineEmits<{
   (e: 'close'): void
   (e: 'confirm'): void
+  (e: 'clickOutside'): void
 }>()
 
 /**
@@ -158,6 +160,7 @@ onBeforeUnmount(() => {
         :class="{ 'av-modal--opened av-w-full av-h-full': opened }"
         :open="opened"
         @keydown.esc="emit('close')"
+        @click.self="emit('clickOutside')"
       >
         <div class="av-container av-container--md av-container--lg av-container-fluid av-w-full">
           <div class="av-modal__body av-pt-sm av-pt-none--md">


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR adds a `clickOutside` event to the `AvModal` component. When a user clicks on the backdrop (outside the modal content area), the new event is emitted, allowing parent components to react (e.g. close the modal).

**Main changes:**
- ✨ Adds `clickOutside` emit to `AvModal.vue` using `@click.self` on the `<dialog>` element
- 📝 Updates `AvModal.md` documentation to reflect the new event (also fixes a typo: `'confirm'` was duplicated as `'close'`)
- ✅ Updates `AvModal.stub.ts` to include `clickOutside` in the emits list
- 🎨 Updates `AvModal.stories.ts` to demonstrate the new event with an alert

---

### Reference to an Issue, Feature, Task, User Story or another PR
Linked to https://github.com/avenirs-esr/AVENIRS-Project/issues/1548

---

### Documentation
- `AvModal.md` updated: new `clickOutside` event added to the events table; pre-existing typo (`'close'` instead of `'confirm'`) fixed
- `AvModal.stories.ts` updated: story now handles `@clickOutside` with an alert to demonstrate the feature

**Modified files:**
- `src/components/overlay/modals/AvModal/AvModal.vue` — Add `clickOutside` emit + `@click.self` handler on `<dialog>`
- `src/components/overlay/modals/AvModal/AvModal.md` — Document new event, fix typo
- `src/components/overlay/modals/AvModal/AvModal.stub.ts` — Add `clickOutside` to emits
- `src/components/overlay/modals/AvModal/AvModal.stories.ts` — Demonstrate `clickOutside` in Storybook story

---

### Target Branch
`develop`

---

### Additional Notes
The implementation relies on the native `@click.self` Vue modifier on the `<dialog>` element. Since the `<dialog>` covers the full viewport as the backdrop, any click that does not originate from a child element will target the `<dialog>` directly and trigger the event. This approach is lightweight and does not require any extra wrapper or JavaScript logic.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

- [ ] a11y tested (no accessibility changes introduced)
- [ ] Tests provided (stub updated; no unit test changes required for this event addition)
- [ ] i18n handled (no text changes)
- [ ] Performance tests (no performance impact)
- [ ] No unnecessary code (`eslint-disable no-alert` added in story only for the demo alert)
- [ ] Code style and formatting rules respected (linting passed)
- [ ] Semantic Versioning respected (conventional commit used)
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process (no database or property changes)