### PR TITLE
fix(1619): AvMessage - prevent AvIconText from being truncated

### DIFF
--- a/src/components/base/AvMessage/AvMessage.vue
+++ b/src/components/base/AvMessage/AvMessage.vue
@@ -85,6 +85,7 @@ const role = computed(() => (type === 'error' || type === 'warning' ? 'alert' : 
       :class="`av-message--${type}`"
       v-bind="avIconTextProps"
       :text="msg"
+      inline
     />
   </div>
 </template>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR fixes a display issue in `AvMessage` where `AvIconText` content could be visually truncated in file upload error scenarios.

**Main changes:**
- 🐛 Prevents truncation of message content by rendering `AvIconText` in inline mode within `AvMessage`
- 💄 Improves UI readability for long or multi-part error messages

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1619

---

### Documentation
- Updated the `AvMessage` base component behavior to pass `inline` to `AvIconText`

**Modified files:**
- `src/components/base/AvMessage/AvMessage.vue` - add `inline` prop on `AvIconText`

---

### Target Branch
develop

---

### Additional Notes
The change is intentionally minimal and scoped to message rendering behavior so existing usages of `AvMessage` continue to work without API changes.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
