### PR TITLE
feat: AvAccordion - add triggerBorderColor

### DIFF
--- a/src/components/interaction/accordions/AvAccordion/AvAccordion.md
+++ b/src/components/interaction/accordions/AvAccordion/AvAccordion.md
@@ -21,6 +21,7 @@ An accordion consists of the following elements:
 | `icon` | `string` | `undefined` | | Accordion icon. |
 | `headingLevel` | `'h2' \| 'h3' \| 'h4' \| 'h5' \| 'h6'` | `'h3'` | | Heading level for the accordion title. |
 | `overflowVisible` | `boolean` | `false` | | Whether the overflow of the accordion content should be visible when expanded. |
+| `triggerBorderColor` | `string` | `'transparent'` | | Border color of the accordion trigger. If set to 'transparent', the trigger will have no border and the arrow will inherit the text color. |
 
 ## 🔊 Events
 
@@ -51,6 +52,7 @@ You can find examples of use and demo of the component on its dedicated [Storybo
       title="Accordion 2"
       icon="mdi:plus-circle-outline"
       overflow-visible
+      trigger-border-color="var(--dark-background-error)"
     >
       <span>Second accordion content</span>
     </AvAccordion>

--- a/src/components/interaction/accordions/AvAccordion/AvAccordion.stories.ts
+++ b/src/components/interaction/accordions/AvAccordion/AvAccordion.stories.ts
@@ -34,10 +34,12 @@ const meta: Meta<AvAccordionProps> = {
       control: { type: 'select', options: ['h2', 'h3', 'h4', 'h5', 'h6'] },
     },
     overflowVisible: { control: 'boolean' },
+    triggerBorderColor: { control: 'color' },
   },
   args: {
     title: 'Accordion 1',
     icon: 'mdi:home-variant-outline',
+    triggerBorderColor: 'transparent',
   },
 }
 

--- a/src/components/interaction/accordions/AvAccordion/AvAccordion.stub.ts
+++ b/src/components/interaction/accordions/AvAccordion/AvAccordion.stub.ts
@@ -2,7 +2,7 @@ import { registerAccordionKey } from '@/components/interaction/accordions/inject
 
 export const AvAccordionStub = defineComponent({
   name: 'AvAccordion',
-  props: ['title', 'icon'],
+  props: ['title', 'icon', 'triggerBorderColor'],
   template: `
     <div class="av-accordion">
       <button

--- a/src/components/interaction/accordions/AvAccordion/AvAccordion.vue
+++ b/src/components/interaction/accordions/AvAccordion/AvAccordion.vue
@@ -35,9 +35,16 @@ export interface AvAccordionProps {
    * @default false
    */
   overflowVisible?: boolean
+
+  /**
+   * Border color of the accordion trigger. If set to 'transparent', the trigger will have no border and the arrow will inherit the text color.
+   * @default 'transparent'
+   */
+  triggerBorderColor?: string
 }
 
-const { id, title, icon, headingLevel = 'h3', overflowVisible = false } = defineProps<AvAccordionProps>()
+const { id, title, icon, headingLevel = 'h3', overflowVisible = false, triggerBorderColor = 'transparent' } = defineProps<AvAccordionProps>()
+
 /**
  * Slots available in the AvAccordion component.
  * The default slot contains the content of the accordion.
@@ -59,6 +66,7 @@ const {
 
 const accordionHeaderId = id ?? `accordion-${crypto.randomUUID()}`
 const accordionPanelId = computed(() => `${accordionHeaderId}-panel`)
+const triggerColor = computed(() => triggerBorderColor === 'transparent' ? 'currentColor' : triggerBorderColor)
 
 const isStandaloneActive = ref()
 const triggerRef = ref<HTMLElement | null>(null)
@@ -157,6 +165,9 @@ watch(isActive, (newValue, oldValue) => {
     max-height: none;
     min-height: var(--dimension-2xl);
     overflow: initial;
+
+    border: 1px solid v-bind(triggerBorderColor);
+    color: v-bind(triggerColor);
 
     &::after, &::before {
       display: block;


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR introduces a new `triggerBorderColor` prop on `AvAccordion` to control the trigger border color and align trigger text/icon color behavior.

**Main changes:**
- ✨ Add `triggerBorderColor` prop to `AvAccordion` with default `transparent`
- 💄 Update component styling to bind trigger border and computed trigger color
- 📝 Update component documentation and usage example
- 🎨 Update Storybook controls/args for visual testing
- ✅ Update component stub props for test compatibility

---

### Reference to an Issue, Feature, Task, User Story or another PR
No issue number could be extracted from the branch name (`feat/av-accordion-add-trigger-border-color`).

---

### Documentation
- Added `triggerBorderColor` in `AvAccordion` props table and example usage
- Added Storybook control for `triggerBorderColor`

**Modified files:**
- `src/components/interaction/accordions/AvAccordion/AvAccordion.vue` - add prop, computed color, and style bindings
- `src/components/interaction/accordions/AvAccordion/AvAccordion.md` - document prop and usage example
- `src/components/interaction/accordions/AvAccordion/AvAccordion.stories.ts` - add control and default arg
- `src/components/interaction/accordions/AvAccordion/AvAccordion.stub.ts` - include prop in stub

---

### Target Branch
`develop`

---

### Additional Notes
When `triggerBorderColor` is set to `transparent`, the trigger now uses `currentColor` for text/icon consistency while keeping a no-border visual style.

---

### Known Limitations or Side Effects
No known side effects.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
