### PR TITLE
feat(1604): AvPeriodInput - add an optional inProgress disabled radio button

### DIFF
--- a/a11y/tests/interaction/inputs/AvPeriodInput.a11y.test.ts
+++ b/a11y/tests/interaction/inputs/AvPeriodInput.a11y.test.ts
@@ -16,6 +16,7 @@ const stories = [
   'MonthType',
   'DateTimeLocalType',
   'HiddenLabel',
+  'InProgress'
 ]
 
 testStories(component, title, stories)

--- a/src/components/interaction/inputs/AvPeriodInput/AvPeriodInput.md
+++ b/src/components/interaction/inputs/AvPeriodInput/AvPeriodInput.md
@@ -37,6 +37,7 @@ This component uses a **discriminated union** based on `showEachInputLabel`:
 | `endErrorMessage`   | `string` | `''` |  | Error message for end input.                                                          |
 | `startDateDisabled` | `boolean` | `false` |  | If `true`, disable only the start date input.                                         |
 | `endDateDisabled`   | `boolean` | `false` |  | If `true`, disable only the end date input.                                           |
+| `inProgressLabel`  | `string` | `'In progress'` |  | Label for the "in progress" state when the end date is disabled and empty.                      |
 | `width`             | `string` |  |  | Optional width for both inputs (CSS value).                                           |
 | `startMinDate`      | `Date` |  |  | Minimum selectable date for the start input.                                          |
 | `startMaxDate`      | `Date` |  |  | Maximum selectable date for the start input. Also impacted by the selected end date.  |

--- a/src/components/interaction/inputs/AvPeriodInput/AvPeriodInput.stories.ts
+++ b/src/components/interaction/inputs/AvPeriodInput/AvPeriodInput.stories.ts
@@ -233,3 +233,11 @@ WithEachInputLabelAndErrors.args = {
   endErrorMessage: 'The end date cannot be before the start date.',
   width: '14.875rem',
 }
+
+export const InProgress = Template.bind({})
+InProgress.args = {
+  startModelValue: '2026-01-10',
+  inProgressLabel: 'In progress',
+  width: '14.875rem',
+  endDateDisabled: true,
+}

--- a/src/components/interaction/inputs/AvPeriodInput/AvPeriodInput.stub.ts
+++ b/src/components/interaction/inputs/AvPeriodInput/AvPeriodInput.stub.ts
@@ -21,6 +21,7 @@ export const AvPeriodInputStub = defineComponent({
     labelVisible: Boolean,
     startErrorMessage: String,
     endErrorMessage: String,
+    inProgressLabel: String,
   },
   emits: ['update:startModelValue', 'update:endModelValue', 'change'],
   template: `<div class="av-period-input-stub" data-testid="av-period-input-stub" />`,

--- a/src/components/interaction/inputs/AvPeriodInput/AvPeriodInput.test.ts
+++ b/src/components/interaction/inputs/AvPeriodInput/AvPeriodInput.test.ts
@@ -2,6 +2,8 @@ import { mount, type VueWrapper } from '@vue/test-utils'
 import { parseISO } from 'date-fns'
 import { beforeEach } from 'vitest'
 import AvPeriodInput, { type AvPeriodInputProps } from '@/components/interaction/inputs/AvPeriodInput/AvPeriodInput.vue'
+import { AvRadioButtonStub } from '@/components/interaction/radios/AvRadioButton/AvRadioButton.stub'
+import { AvRadioButtonSetStub } from '@/components/interaction/radios/AvRadioButtonSet/AvRadioButtonSet.stub'
 import { AvInputStub, BddTest } from '@/tests'
 
 BddTest().given('a period input', () => {
@@ -9,6 +11,8 @@ BddTest().given('a period input', () => {
 
   const stubs = {
     AvInput: AvInputStub,
+    AvRadioButtonSet: AvRadioButtonSetStub,
+    AvRadioButton: AvRadioButtonStub,
   }
 
   const requiredProps: AvPeriodInputProps = {
@@ -256,6 +260,24 @@ BddTest().given('a period input', () => {
 
       expect(startInput.props('disabled')).toBe(false)
       expect(endInput.props('disabled')).toBe(true)
+    })
+  })
+
+  BddTest().and('given endDateDisabled is true and inProgressLabel is provided', () => {
+    const props: AvPeriodInputProps = {
+      ...requiredProps,
+      endDateDisabled: true,
+      inProgressLabel: 'In progress',
+    }
+
+    beforeEach(() => {
+      wrapper = mount(AvPeriodInput, { props, global: { stubs } })
+    })
+
+    BddTest().then('it should render the radio button set instead of the end date input', () => {
+      expect(wrapper.find('[data-testid="av-radio-button-set-stub"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="end-date-input"]').exists()).toBe(false)
+      expect(wrapper.find('.b2-regular').text()).toBe('In progress')
     })
   })
 

--- a/src/components/interaction/inputs/AvPeriodInput/AvPeriodInput.vue
+++ b/src/components/interaction/inputs/AvPeriodInput/AvPeriodInput.vue
@@ -105,6 +105,11 @@ interface AvPeriodInputBaseProps {
    * Error message for end input
    */
   endErrorMessage?: string
+
+  /**
+   * Label for the "in progress" state when the end date is disabled and empty
+   */
+  inProgressLabel?: string
 }
 
 export type AvPeriodInputProps = AvPeriodInputBaseProps & (
@@ -156,6 +161,7 @@ const {
   startErrorMessage,
   endErrorMessage,
   showEachInputLabel = false,
+  inProgressLabel,
 } = defineProps<AvPeriodInputProps>()
 
 /**
@@ -261,7 +267,25 @@ function onEndUpdate (value: string | number | null) {
         @update:model-value="onStartUpdate($event)"
       />
 
+      <AvRadioButtonSet
+        v-if="!endModelValue && endDateDisabled && !!inProgressLabel"
+        model-value="in-progress"
+        name="in-progress"
+        inline
+        small
+      >
+        <AvRadioButton
+          value="in-progress"
+          disabled
+        >
+          <div>
+            <span class="b2-regular">{{ inProgressLabel }}</span>
+          </div>
+        </AvRadioButton>
+      </AvRadioButtonSet>
+
       <AvInput
+        v-else
         :id="endId"
         :type="type"
         :model-value="endModelValue"
@@ -292,5 +316,10 @@ function onEndUpdate (value: string | number | null) {
   &__separator {
     flex: 0 0 auto;
   }
+
+  :deep(.av-fieldset__element--disabled:has(.av-radio-group)) {
+    opacity: 1 !important;
+  }
+
 }
 </style>

--- a/src/components/interaction/radios/AvRadioButton/AvRadioButton.stub.ts
+++ b/src/components/interaction/radios/AvRadioButton/AvRadioButton.stub.ts
@@ -1,0 +1,8 @@
+export const AvRadioButtonStub = defineComponent({
+  name: 'AvRadioButton',
+  props: {
+    value: String,
+    disabled: Boolean,
+  },
+  template: '<div class="av-radio-button-stub"><slot /></div>',
+})

--- a/src/components/interaction/radios/AvRadioButtonSet/AvRadioButtonSet.stub.ts
+++ b/src/components/interaction/radios/AvRadioButtonSet/AvRadioButtonSet.stub.ts
@@ -1,0 +1,11 @@
+export const AvRadioButtonSetStub = defineComponent({
+  name: 'AvRadioButtonSet',
+  props: {
+    modelValue: String,
+    name: String,
+    inline: Boolean,
+    small: Boolean,
+  },
+  emits: ['update:modelValue'],
+  template: '<div class="av-radio-button-set-stub" data-testid="av-radio-button-set-stub"><slot /></div>',
+})

--- a/src/tests/index.ts
+++ b/src/tests/index.ts
@@ -17,6 +17,8 @@ import { AvCheckboxListItemStub } from '@/components/interaction/lists/AvCheckbo
 import { AvListStub } from '@/components/interaction/lists/AvList/AvList.stub'
 import { AvListItemStub } from '@/components/interaction/lists/AvListItem/AvListItem.stub'
 import { AvTagPickerStub } from '@/components/interaction/pickers/AvTagPicker/AvTagPicker.stub'
+import { AvRadioButtonStub } from '@/components/interaction/radios/AvRadioButton/AvRadioButton.stub'
+import { AvRadioButtonSetStub } from '@/components/interaction/radios/AvRadioButtonSet/AvRadioButtonSet.stub'
 import { AvAutocompleteStub } from '@/components/interaction/selects/AvAutocomplete/AvAutocomplete.stub'
 import { AvMultiselectStub } from '@/components/interaction/selects/AvMultiselect/AvMultiselect.stub'
 import { AvSelectStub } from '@/components/interaction/selects/AvSelect/AvSelect.stub'
@@ -60,6 +62,8 @@ export {
   AvPaginationStub,
   AvPeriodInputStub,
   AvPopoverStub,
+  AvRadioButtonSetStub,
+  AvRadioButtonStub,
   AvSelectStub,
   AvSideNavigationStub,
   AvStepperStub,


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> _Describe the changes introduced by this pull request._

This PR updates AvPeriodInput to support an optional in-progress radio state when the end date is disabled and no end value is selected. It adds the radio button branch in the component, extends the stub and test coverage, documents the new prop, and exposes a matching story for manual verification.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Linked to https://github.com/avenirs-esr/AVENIRS-Project/issues/1604

---

### Documentation
> _Detail any updates made to documentation, configuration steps, or technical specs._

- Documented the new `inProgressLabel` prop in the AvPeriodInput docs.
- Added a dedicated Storybook example for the in-progress state.
- Updated the component stub and tests to reflect the new disabled-state behavior.

---

### Target Branch
> _Which branch is this PR targeting (e.g. `main`, `develop`)?_

`develop`

---

### Additional Notes
> _Include any relevant context, technical details, or reasons behind certain decisions._

The end date input is now replaced by a disabled radio button set when `endDateDisabled` is true, `endModelValue` is empty, and `inProgressLabel` is provided. The current test suite covers the new branch and the existing range/min-max behavior remains unchanged.

---

### Known Limitations or Side Effects
> _List any limitations, known bugs, or side effects this PR may introduce._

No known limitations or side effects beyond the intended UI branch for in-progress periods.

---


## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [x] Add to `CHANGELOG.md` file all properties and database change and details for the update process
