### PR TITLE
feat: AvSideMenu, AvSideNavigation - add hideContentWhenCollapsed prop

### DIFF
--- a/a11y/tests/navigation/AvSideMenu.a11y.test.ts
+++ b/a11y/tests/navigation/AvSideMenu.a11y.test.ts
@@ -4,6 +4,8 @@ const component = 'AvSideMenu'
 const title = 'Components/Navigation/AvSideMenu'
 const stories = [
   'Default',
+  'Collapsed',
+  'HiddenContentCollapsed',
   'NonCollapsible',
   'CustomWidth',
   'StudentNavigation',

--- a/a11y/tests/navigation/AvSideNavigation.a11y.test.ts
+++ b/a11y/tests/navigation/AvSideNavigation.a11y.test.ts
@@ -1,13 +1,15 @@
 import { testStories } from 'a11y/utils'
 
 const component = 'AvSideNavigation'
-const title = 'Components/Navigation/AvSideMenu'
+const title = 'Components/Navigation/AvSideNavigation'
 const stories = [
   'Default',
   'MenuItems',
   'Collapsed',
+  'HiddenContentCollapsed',
   'CustomWidth',
   'CustomCollapsedWidth',
+  'CustomColor',
 ]
 
 testStories(component, title, stories)

--- a/src/components/interaction/lists/AvListItem/AvListItem.vue
+++ b/src/components/interaction/lists/AvListItem/AvListItem.vue
@@ -212,6 +212,7 @@ function handleKeyDown (event: KeyboardEvent) {
   >
     <component
       :is="componentTag"
+      :title="title"
       :aria-label="clickable ? computedAriaLabel : undefined"
       :aria-describedby="ariaDescribedby"
       :aria-disabled="disabled && isButton ? 'true' : undefined"

--- a/src/components/navigation/AvSideMenu/AvSideMenu.md
+++ b/src/components/navigation/AvSideMenu/AvSideMenu.md
@@ -23,6 +23,7 @@ The component integrates focus management, proper ARIA attributes, and responsiv
 | `collapsible` | `boolean` | `true` |  | Whether the collapsing feature is enabled |
 | `width` | `string` | `'16rem'` |  | Width of the side-menu when expanded |
 | `collapsedWidth` | `string` | `'5rem'` |  | Width of the side-menu when collapsed |
+| `hideContentWhenCollapsed` | `boolean` | `false` |  | Whether to hide the content when the menu is collapsed |
 
 ### v-model
 

--- a/src/components/navigation/AvSideMenu/AvSideMenu.stories.ts
+++ b/src/components/navigation/AvSideMenu/AvSideMenu.stories.ts
@@ -70,7 +70,14 @@ export default meta
 const Template: StoryFn<AvSideMenuProps> = args => ({
   components: { AvSideMenu },
   setup () {
-    const isCollapsed = ref(false)
+    const isCollapsed = ref(args.collapsed ?? false)
+
+    watch(
+      () => args.collapsed,
+      (value) => {
+        isCollapsed.value = value ?? false
+      }
+    )
 
     const handleCollapseChange = (collapsed: boolean) => {
       isCollapsed.value = collapsed
@@ -97,15 +104,15 @@ const Template: StoryFn<AvSideMenuProps> = args => ({
           
           <nav style="flex: 1;">
             <div style="display: flex; flex-direction: column; gap: 0.5rem;">
-              <a href="#" style="display: flex; align-items: center; gap: 0.75rem; padding: 0.75rem; color: var(--text1); text-decoration: none; border-radius: var(--radius-md); background-color: var(--dark-background-primary1); color: white;">
+                 <a href="#" aria-label="Home" style="display: flex; align-items: center; gap: 0.75rem; padding: 0.75rem; color: var(--text1); text-decoration: none; border-radius: var(--radius-md); background-color: var(--dark-background-primary1); color: white;">
                 <svg width="20" height="20" viewBox="0 0 24 24" style="flex-shrink: 0;"><path fill="currentColor" d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/></svg>
                 <span v-if="!isCollapsed" style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Home</span>
               </a>
-              <a href="#" style="display: flex; align-items: center; gap: 0.75rem; padding: 0.75rem; color: var(--text1); text-decoration: none; border-radius: var(--radius-md);">
+                 <a href="#" aria-label="Profile" style="display: flex; align-items: center; gap: 0.75rem; padding: 0.75rem; color: var(--text1); text-decoration: none; border-radius: var(--radius-md);">
                 <svg width="20" height="20" viewBox="0 0 24 24" style="flex-shrink: 0;"><path fill="currentColor" d="M12 2C13.1 2 14 2.9 14 4C14 5.1 13.1 6 12 6C10.9 6 10 5.1 10 4C10 2.9 10.9 2 12 2ZM21 9V7L15 6.5V9C15 10.1 14.1 11 13 11S11 10.1 11 9V7.5L5 8V10H6V16C6 17.1 6.9 18 8 18H10V22H12V18H14V22H16V18H18C19.1 18 20 17.1 20 16V10H21V9Z"/></svg>
                 <span v-if="!isCollapsed" style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Profile</span>
               </a>
-              <a href="#" style="display: flex; align-items: center; gap: 0.75rem; padding: 0.75rem; color: var(--text1); text-decoration: none; border-radius: var(--radius-md);">
+                 <a href="#" aria-label="Settings" style="display: flex; align-items: center; gap: 0.75rem; padding: 0.75rem; color: var(--text1); text-decoration: none; border-radius: var(--radius-md);">
                 <svg width="20" height="20" viewBox="0 0 24 24" style="flex-shrink: 0;"><path fill="currentColor" d="M12,15.5A3.5,3.5 0 0,1 8.5,12A3.5,3.5 0 0,1 12,8.5A3.5,3.5 0 0,1 15.5,12A3.5,3.5 0 0,1 12,15.5M19.43,12.97C19.47,12.65 19.5,12.33 19.5,12C19.5,11.67 19.47,11.34 19.43,11L21.54,9.37C21.73,9.22 21.78,8.95 21.66,8.73L19.66,5.27C19.54,5.05 19.27,4.96 19.05,5.05L16.56,6.05C16.04,5.66 15.5,5.32 14.87,5.07L14.5,2.42C14.46,2.18 14.25,2 14,2H10C9.75,2 9.54,2.18 9.5,2.42L9.13,5.07C8.5,5.32 7.96,5.66 7.44,6.05L4.95,5.05C4.73,4.96 4.46,5.05 4.34,5.27L2.34,8.73C2.22,8.95 2.27,9.22 2.46,9.37L4.57,11C4.53,11.34 4.5,11.67 4.5,12C4.5,12.33 4.53,12.65 4.57,12.97L2.46,14.63C2.27,14.78 2.22,15.05 2.34,15.27L4.34,18.73C4.46,18.95 4.73,19.03 4.95,18.95L7.44,17.94C7.96,18.34 8.5,18.68 9.13,18.93L9.5,21.58C9.54,21.82 9.75,22 10,22H14C14.25,22 14.46,21.82 14.5,21.58L14.87,18.93C15.5,18.68 16.04,18.34 16.56,17.94L19.05,18.95C19.27,19.03 19.54,18.95 19.66,18.73L21.66,15.27C21.78,15.05 21.73,14.78 21.54,14.63L19.43,12.97Z"/></svg>
                 <span v-if="!isCollapsed" style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Settings</span>
               </a>
@@ -127,6 +134,17 @@ const Template: StoryFn<AvSideMenuProps> = args => ({
 export const Default = Template.bind({})
 Default.args = {}
 
+export const Collapsed = Template.bind({})
+Collapsed.args = {
+  collapsed: true
+}
+
+export const HiddenContentCollapsed = Template.bind({})
+HiddenContentCollapsed.args = {
+  collapsed: true,
+  hideContentWhenCollapsed: true
+}
+
 export const NonCollapsible = Template.bind({})
 NonCollapsible.args = {
   collapsible: false
@@ -141,8 +159,15 @@ CustomWidth.args = {
 const StudentNavigationTemplate: StoryFn<AvSideMenuProps> = args => ({
   components: { AvSideMenu },
   setup () {
-    const isCollapsed = ref(false)
+    const isCollapsed = ref(args.collapsed ?? false)
     const activeRoute = ref('/')
+
+    watch(
+      () => args.collapsed,
+      (value) => {
+        isCollapsed.value = value ?? false
+      }
+    )
 
     const navigationItems = [
       { path: '/', label: 'Mon parcours', icon: MDI_ICONS.HOME_VARIANT_OUTLINE },
@@ -231,7 +256,14 @@ StudentNavigation.args = { }
 const MinimalTemplate: StoryFn<AvSideMenuProps> = args => ({
   components: { AvSideMenu },
   setup () {
-    const isCollapsed = ref(false)
+    const isCollapsed = ref(args.collapsed ?? false)
+
+    watch(
+      () => args.collapsed,
+      (value) => {
+        isCollapsed.value = value ?? false
+      }
+    )
 
     return {
       args,

--- a/src/components/navigation/AvSideMenu/AvSideMenu.test.ts
+++ b/src/components/navigation/AvSideMenu/AvSideMenu.test.ts
@@ -334,4 +334,33 @@ BddTest().given('an AvSideMenu component', () => {
       })
     })
   })
+
+  BddTest().and('with hide content when collapsed', () => {
+    let wrapper: ReturnType<typeof mount<typeof AvSideMenu>>
+
+    beforeEach(() => {
+      wrapper = mount<typeof AvSideMenu>(AvSideMenu, {
+        props: {
+          hideContentWhenCollapsed: true
+        }
+      })
+    })
+
+    BddTest().when('the component is not collapsed', () => {
+      BddTest().then('it should show the content', () => {
+        const content = wrapper.find('.av-side-menu__content')
+        expect(content.exists()).toBe(true)
+      })
+    })
+
+    BddTest().when('the component is collapsed', () => {
+      BddTest().then('it should hide the content', async () => {
+        await wrapper.setProps({ collapsed: true })
+        const sideMenu = wrapper.find('.av-side-menu')
+        expect(sideMenu.exists()).toBe(true)
+        expect(wrapper.find('.av-side-menu--collapsed').exists()).toBe(true)
+        expect(wrapper.find('.av-side-menu__content').exists()).toBe(false)
+      })
+    })
+  })
 })

--- a/src/components/navigation/AvSideMenu/AvSideMenu.vue
+++ b/src/components/navigation/AvSideMenu/AvSideMenu.vue
@@ -30,6 +30,12 @@ export interface AvSideMenuProps {
    * Custom padding for the side-menu content
    */
   padding?: string
+
+  /**
+   * Whether to hide the content when the menu is collapsed
+   * @default false
+   */
+  hideContentWhenCollapsed?: boolean
 }
 
 const props = withDefaults(defineProps<AvSideMenuProps>(), {
@@ -37,7 +43,8 @@ const props = withDefaults(defineProps<AvSideMenuProps>(), {
   collapsed: false,
   width: '16rem',
   collapsedWidth: '5rem',
-  padding: '0'
+  padding: '0',
+  hideContentWhenCollapsed: false
 })
 
 /**
@@ -119,7 +126,10 @@ function toggleCollapse () {
       />
     </div>
 
-    <div class="av-side-menu__content av-row av-flex-fill av-py-sm">
+    <div
+      v-if="!(hideContentWhenCollapsed && collapsed)"
+      class="av-side-menu__content av-row av-flex-fill av-py-sm"
+    >
       <slot />
     </div>
   </nav>

--- a/src/components/navigation/AvSideNavigation/AvSideNavigation.md
+++ b/src/components/navigation/AvSideNavigation/AvSideNavigation.md
@@ -27,6 +27,7 @@ The component integrates:
 | `width` | `string` | `'fit-content'` | | Width of the side menu when expanded |
 | `collapsedWidth` | `string` | `'3.5rem'` | | Width of the side menu when collapsed |
 | `selectedItemColor` | `string` | `'var(--dark-background-primary1)'` | | Color of selected item background and icon. |
+| `hideContentWhenCollapsed` | `boolean` | `false` |  | Whether to hide the content when the menu is collapsed |
 
 ### AvSideNavigationItem Interface
 

--- a/src/components/navigation/AvSideNavigation/AvSideNavigation.stories.ts
+++ b/src/components/navigation/AvSideNavigation/AvSideNavigation.stories.ts
@@ -212,6 +212,33 @@ export const Collapsed: Story = {
   })
 }
 
+export const HiddenContentCollapsed: Story = {
+  render: args => ({
+    components: { AvSideNavigation },
+    setup () {
+      const selectedItem = ref({ itemId: 'educations' })
+      const isSideMenuCollapsed = ref(true)
+      return { args, selectedItem, isSideMenuCollapsed }
+    },
+    template: `
+      <div style="height: 400px; display: flex;">
+        <AvSideNavigation 
+          v-bind="args"
+          hide-content-when-collapsed
+          v-model:selected-item="selectedItem"
+          v-model:is-side-menu-collapsed="isSideMenuCollapsed"
+        />
+        <div style="flex: 1; padding: 1rem; background: #f5f5f5;">
+          <p><strong>Selected item:</strong> {{ selectedItem.itemId }}</p>
+          <p><strong>Parent item:</strong> {{ selectedItem.parentId }}</p>
+          <p><strong>Menu collapsed:</strong> {{ isSideMenuCollapsed }}</p>
+          <p>This story demonstrates the collapsed state where only collapse button is visible.</p>
+        </div>
+      </div>
+    `
+  })
+}
+
 export const CustomdWidth: Story = {
   render: args => ({
     components: { AvSideNavigation },
@@ -295,6 +322,6 @@ export const CustomColor: Story = {
     `
   }),
   args: {
-    selectedItemColor: '#4caf50'
+    selectedItemColor: 'var(--dark-background-warn)'
   }
 }

--- a/src/components/navigation/AvSideNavigation/AvSideNavigation.stub.ts
+++ b/src/components/navigation/AvSideNavigation/AvSideNavigation.stub.ts
@@ -7,6 +7,7 @@ export const AvSideNavigationStub = defineComponent({
       required: true
     },
     isSideMenuCollapsed: Boolean,
+    hideContentWhenCollapsed: Boolean,
     collapsedWidth: String
   },
   emits: ['update:selectedItem', 'update:isSideMenuCollapsed'],

--- a/src/components/navigation/AvSideNavigation/AvSideNavigation.test.ts
+++ b/src/components/navigation/AvSideNavigation/AvSideNavigation.test.ts
@@ -198,11 +198,11 @@ BddTest().given('an AvSideNavigation component', () => {
       })
     })
 
-    BddTest().then('it should not show titles for list items', () => {
+    BddTest().then('it should still show titles for list items', () => {
       const listItems = wrapper.findAllComponents({ name: 'AvListItem' })
 
       listItems.forEach((item) => {
-        expect(item.props('title')).toBeUndefined()
+        expect(item.props('title')).toBeDefined()
       })
     })
 

--- a/src/components/navigation/AvSideNavigation/AvSideNavigation.vue
+++ b/src/components/navigation/AvSideNavigation/AvSideNavigation.vue
@@ -45,9 +45,15 @@ export interface AvSideNavigationProps {
    * Color of selected item background and icon.
    */
   selectedItemColor?: string
+
+  /**
+   * Whether to hide the content when the menu is collapsed
+   * @default false
+   */
+  hideContentWhenCollapsed?: boolean
 }
 
-const { items, width = 'fit-content', collapsedWidth = '3.5rem', selectedItemColor } = defineProps<AvSideNavigationProps>()
+const { items, width = 'fit-content', collapsedWidth = '3.5rem', selectedItemColor, hideContentWhenCollapsed = false } = defineProps<AvSideNavigationProps>()
 
 const selectedItem = defineModel<AvSideNavigationSelectedItem>('selectedItem', {
   default: () => ({ itemId: '' })
@@ -100,6 +106,7 @@ watchEffect(() => {
     :width="width"
     :collapsed-width="collapsedWidth"
     :color="selectedItemColor"
+    :hide-content-when-collapsed="hideContentWhenCollapsed"
   >
     <AvList
       size="small"
@@ -110,7 +117,7 @@ watchEffect(() => {
         :key="item.id"
       >
         <AvListItem
-          :title="isSideMenuCollapsed ? undefined : item.label"
+          :title="item.label"
           :icon="item.icon"
           :icon-size="1.8"
           :selected="isItemSelected(item)"
@@ -136,7 +143,7 @@ watchEffect(() => {
               <AvListItem
                 v-for="subitem in item.children"
                 :key="subitem.id"
-                :title="isSideMenuCollapsed ? undefined : subitem.label"
+                :title="subitem.label"
                 :icon="subitem.icon"
                 :icon-size="1.8"
                 :selected="isSubItemSelected(item, subitem)"


### PR DESCRIPTION
:sparkles: AvSideMenu, AvSideNavigation - add hideContentWhenCollapsed prop

AvSideMenu

<img width="1066" height="777" alt="image" src="https://github.com/user-attachments/assets/c9796f8f-8dca-4f9e-ae5d-f37075b4d73c" />

<img width="1059" height="778" alt="image" src="https://github.com/user-attachments/assets/eee4cc95-2fcc-4397-854d-625baedf0b61" />

AvSideNavigation

<img width="1069" height="583" alt="image" src="https://github.com/user-attachments/assets/075dd9c2-0924-4f4b-9842-a6b6c160b82e" />

<img width="1041" height="566" alt="image" src="https://github.com/user-attachments/assets/e577a327-43e9-4431-b637-3f98edf7f5a7" />
