### PR TITLE
refactor: improve av-max-lines

### DIFF
--- a/src/styles/utilities/_text.md
+++ b/src/styles/utilities/_text.md
@@ -25,6 +25,10 @@ This `text` utility generates text-related classes for all defined styles.
   display: -webkit-box !important;
   -webkit-box-orient: vertical !important;
   overflow: hidden !important;
+  white-space: normal !important;
+  text-overflow: ellipsis !important;
+  overflow-wrap: anywhere !important;
+  word-break: break-word !important;
   line-clamp: var(--max-lines) !important;
   -webkit-line-clamp: var(--max-lines) !important;
 }

--- a/src/styles/utilities/_text.scss
+++ b/src/styles/utilities/_text.scss
@@ -9,6 +9,10 @@
   display: -webkit-box !important;
   -webkit-box-orient: vertical !important;
   overflow: hidden !important;
+  white-space: normal !important;
+  text-overflow: ellipsis !important;
+  overflow-wrap: anywhere !important;
+  word-break: break-word !important;
   line-clamp: var(--max-lines) !important;
   -webkit-line-clamp: var(--max-lines) !important;
 }


### PR DESCRIPTION
:recycle: av-max-lines - prevent inherited single-line constraints from breaking multi-line clamp