### PR TITLE
feat: AvSelect - add labelVisible prop

### DIFF
--- a/a11y/tests/interaction/selects/AvSelect.a11y.test.ts
+++ b/a11y/tests/interaction/selects/AvSelect.a11y.test.ts
@@ -12,6 +12,7 @@ const stories = [
   'WithError',
   'WithSuccess',
   'WithPrefixIcon',
+  'LabelInvisible',
   'WithOptGroups',
   'WithOptGroupsAndSelectedItem',
 ]

--- a/src/components/interaction/selects/AvSelect/AvSelect.md
+++ b/src/components/interaction/selects/AvSelect/AvSelect.md
@@ -27,6 +27,7 @@ The `AvSelect` consists of a set of `<option>` within a `<select>`. If an option
 | `id` | `string` | `select-${crypto.randomUUID()}` | | Unique id for the select. Used for the accessibility. |
 | `dense` | `boolean` | `false` | | Dense mode for reduced padding.|
 | `prefixIcon` | `string` | | | Prefix icon name (optional).|
+| `labelVisible` | `boolean` | `true` | | Whether the label is visible. |
 
 N.B. The `options` prop is an array of objects with the following structure:
 

--- a/src/components/interaction/selects/AvSelect/AvSelect.stories.ts
+++ b/src/components/interaction/selects/AvSelect/AvSelect.stories.ts
@@ -51,6 +51,7 @@ const meta = {
     errorMessage: { control: 'text' },
     placeholder: { control: 'text', required: true },
     prefixIcon: { control: 'text' },
+    labelVisible: { control: 'boolean' },
   },
   args: {
     options: [
@@ -71,6 +72,7 @@ const meta = {
     errorMessage: '',
     dense: false,
     prefixIcon: '',
+    labelVisible: true,
   },
 }
 
@@ -148,6 +150,21 @@ WithPrefixIcon.args = {
   name: 'with-prefix-icon-select',
   prefixIcon: MDI_ICONS.ACCOUNT_CIRCLE_OUTLINE,
   label: 'With prefix icon Select',
+}
+
+export const LabelInvisible = Template.bind({})
+LabelInvisible.args = {
+  name: 'label-invisible-select',
+  label: 'Invisible label Select',
+  labelVisible: false,
+}
+
+export const LabelInvisibleWithPrefixIcon = Template.bind({})
+LabelInvisibleWithPrefixIcon.args = {
+  name: 'label-invisible-with-prefix-icon-select',
+  label: 'Invisible label with prefix icon Select',
+  labelVisible: false,
+  prefixIcon: MDI_ICONS.ACCOUNT_CIRCLE_OUTLINE,
 }
 
 export const WithOptGroups = Template.bind({})

--- a/src/components/interaction/selects/AvSelect/AvSelect.test.ts
+++ b/src/components/interaction/selects/AvSelect/AvSelect.test.ts
@@ -158,6 +158,22 @@ BddTest().given('a select component', () => {
     })
   })
 
+  BddTest().and('labelVisible is set to false', () => {
+    beforeEach(() => {
+      wrapper = mountWithProps({ label: 'Visible label', labelVisible: false })
+    })
+
+    BddTest().when('the component is mounted', () => {
+      BddTest().then('it should hide the label visually', () => {
+        expect(wrapper.find('label').classes()).toContain('av-sr-only')
+      })
+
+      BddTest().then('it should still keep the label text in the DOM', () => {
+        expect(wrapper.find('label').text()).toContain('Visible label')
+      })
+    })
+  })
+
   BddTest().and('with disabled prop set to true', () => {
     beforeEach(() => {
       wrapper = mountWithProps({ disabled: true })

--- a/src/components/interaction/selects/AvSelect/AvSelect.vue
+++ b/src/components/interaction/selects/AvSelect/AvSelect.vue
@@ -88,6 +88,12 @@ export interface AvSelectProps {
    * Prefix icon name (optional)
    */
   prefixIcon?: string
+
+  /**
+   * Whether the label is visible
+   * @default true
+   */
+  labelVisible?: boolean
 }
 
 defineOptions({
@@ -107,6 +113,7 @@ const {
   placeholder,
   dense = false,
   prefixIcon,
+  labelVisible = true
 } = defineProps<AvSelectProps>()
 
 const selectedItem = defineModel<AvSelectSelectedOption>('selectedItem', {
@@ -137,6 +144,11 @@ const message = computed(() => {
 const messageType = computed(() => {
   return errorMessage ? 'error' : 'success'
 })
+const finalLabelClass = computed(() => [
+  'av-label b2-regular',
+  { 'av-sr-only': !labelVisible },
+])
+const iconsTopPosition = computed(() => labelVisible && label ? '69%' : '50%')
 
 function isOptionGroup (option: AvSelectOption): option is AvSelectOption {
   return Array.isArray(option.children)
@@ -203,7 +215,7 @@ function handleSelectChange (event: Event) {
         </div>
 
         <label
-          class="av-label b2-light"
+          :class="finalLabelClass"
           :for="realId"
         >
           <span>{{ label }}</span>
@@ -304,7 +316,7 @@ function handleSelectChange (event: Event) {
 .av-select-prefix {
   position: absolute;
   left: var(--spacing-xs);
-  top: 69%;
+  top: v-bind(iconsTopPosition);
   transform: translateY(-50%);
   z-index: 1;
   pointer-events: none;


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR adds a new `labelVisible` prop to `AvSelect` so the label can be visually hidden while keeping the text in the DOM for accessibility and assistive technologies.

**Main changes:**
- ♿️ Adds support for visually hiding the label through `labelVisible`
- 📝 Updates the AvSelect story and docs to reflect the new prop
- ✅ Extends component, a11y, and story-related tests

---

### Reference to an Issue, Feature, Task, User Story or another PR
No issue number could be extracted from the branch name `feat/av-select-add-label-visible-prop`.

---

### Documentation
- Updated AvSelect documentation to mention the new `labelVisible` prop.
- Added a story covering the hidden-label state.
- Extended tests to cover the new accessibility behavior.

**Modified files:**
- `src/components/interaction/selects/AvSelect/AvSelect.vue` - add `labelVisible` support
- `src/components/interaction/selects/AvSelect/AvSelect.test.ts` - add label visibility test coverage
- `a11y/tests/interaction/selects/AvSelect.a11y.test.ts` - update accessibility coverage
- `src/components/interaction/selects/AvSelect/AvSelect.md` - document the new prop
- `src/components/interaction/selects/AvSelect/AvSelect.stories.ts` - add a story for the hidden label state

---

### Target Branch
`develop`

---

### Additional Notes
The label text remains in the DOM so the component keeps a readable accessible name, while the visual label can be hidden when the design requires it.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated)
- [x] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [x] Add to `CHANGELOG.md` file all properties and database change and details for the update process
