### PR TITLE
feat: AvTabs - Add lazyRender prop

### DIFF
--- a/src/components/interaction/tabs/AvTabs/AvTabs.md
+++ b/src/components/interaction/tabs/AvTabs/AvTabs.md
@@ -23,6 +23,7 @@ If the number of tabs exceeds the width of the container, a horizontal scroll al
 | `ariaLabel` | `string` | `undefined` | | Aria label of tab list. |
 | `modelValue` | `number` | | ✅ | Index of selected tab at loading (starts at 0). |
 | `compact` | `string` | `undefined` | | Allows compact display: underline without central pipe. |
+| `lazyRender` | `boolean` | `true` | | If false, all tab contents are rendered in the DOM regardless of their active state. |
 
 ## 🔊 Events
 

--- a/src/components/interaction/tabs/AvTabs/AvTabs.stories.ts
+++ b/src/components/interaction/tabs/AvTabs/AvTabs.stories.ts
@@ -50,10 +50,12 @@ const meta: Meta<AvTabsProps> = {
   argTypes: {
     ariaLabel: { control: 'text' },
     compact: { control: 'boolean' },
+    lazyRender: { control: 'boolean' },
   },
   args: {
     ariaLabel: 'Tabs switcher',
     compact: false,
+    lazyRender: true,
   },
 }
 

--- a/src/components/interaction/tabs/AvTabs/AvTabs.stub.ts
+++ b/src/components/interaction/tabs/AvTabs/AvTabs.stub.ts
@@ -9,6 +9,10 @@ export const AvTabsStub = defineComponent({
     },
     ariaLabel: String,
     compact: Boolean,
+    lazyRender: {
+      type: Boolean,
+      default: true,
+    },
   },
   emits: ['update:modelValue'],
   setup (props, { slots }) {
@@ -17,7 +21,11 @@ export const AvTabsStub = defineComponent({
     const activeTab = computed(() => props.modelValue ?? 0)
 
     return () => {
-      return h('div', { class: 'av-tabs' }, tabItems.value[activeTab.value] ?? null)
+      if (props.lazyRender) {
+        return h('div', { class: 'av-tabs' }, tabItems.value[activeTab.value] ?? null)
+      }
+
+      return h('div', { class: 'av-tabs' }, tabItems.value)
     }
   },
 })

--- a/src/components/interaction/tabs/AvTabs/AvTabs.vue
+++ b/src/components/interaction/tabs/AvTabs/AvTabs.vue
@@ -18,12 +18,18 @@ export interface AvTabsProps {
   /**
    * Allows compact display:
    * Underline without central pipe.
-   * @default 'false'
+   * @default false
    */
   compact?: boolean
+
+  /**
+   * If false, all tab contents are rendered in the DOM regardless of their active state.
+   * @default true
+   */
+  lazyRender?: boolean
 }
 
-const { ariaLabel, compact = false } = defineProps<AvTabsProps>()
+const { ariaLabel, compact = false, lazyRender = true } = defineProps<AvTabsProps>()
 
 /**
  * Slots available in AvTabs component.
@@ -159,7 +165,7 @@ onUnmounted(() => {
     >
       <component
         :is="(tab.children as Slots).default"
-        v-if="activeTab === index"
+        v-if="!lazyRender || activeTab === index"
       />
     </TabContent>
   </div>


### PR DESCRIPTION
:sparkles: AvTabs - Add noLazyRender prop to allow all tab contents to be rendered in the DOM regardless of their active state