### PR TITLE
feat: AvCard - improve collapsed

### DIFF
--- a/a11y/tests/cards/AvCard.a11y.test.ts
+++ b/a11y/tests/cards/AvCard.a11y.test.ts
@@ -7,6 +7,7 @@ const stories = [
   'WithCustomColors',
   'WithOnlyDefaultSlot',
   'TitleOnly',
+  'CollapsibleWithDynamicTitle'
 ]
 
 testStories(component, title, stories)

--- a/src/components/cards/AvCard/AvCard.md
+++ b/src/components/cards/AvCard/AvCard.md
@@ -36,7 +36,7 @@ None.
 
 | Name | Description |
 | --- | --- |
-| `title` | Slot to add a title to the card. |
+| `title` | Slot to add a title to the card. Exposes a scoped prop `collapsed` (`boolean`) when used with a collapsible card. |
 | `body` | Slot to add a body to the card. |
 | `footer` | Slot to add a footer to the card. |
 | `default` | Default slot for additional card content. |
@@ -56,6 +56,27 @@ You can find examples of use and demo of the component on its dedicated [Storybo
   >
     <template #title>
       <span>Some content in title</span>
+    </template>
+    <template #body>
+      <span>Some content in body</span>
+    </template>
+    <template #footer>
+      <span>Some content in footer</span>
+    </template>
+  </AvCard>
+</template>
+```
+
+```vue
+<template>
+  <AvCard
+    collapsible
+    background-color="var(--other-background-base)"
+    title-background="var(--other-background-base)"
+    title-height="6rem"
+  >
+    <template #title="{ collapsed }">
+      <span>{{ collapsed ? 'Collapsed title' : 'Expanded title' }}</span>
     </template>
     <template #body>
       <span>Some content in body</span>

--- a/src/components/cards/AvCard/AvCard.stories.ts
+++ b/src/components/cards/AvCard/AvCard.stories.ts
@@ -131,3 +131,26 @@ export const TitleOnly = Template.bind({})
 TitleOnly.args = {
   titleOnly: true,
 }
+
+const TemplateDynamicTitle: StoryFn<AvCardProps> = args => ({
+  components: { AvCard },
+  setup () {
+    return { args }
+  },
+  template: `
+    <AvCard v-bind="args">
+      <template #title="{ collapsed }">
+        <h3 class="n3" style="margin: 0;">{{ collapsed ? 'Collapsed state' : 'Expanded state' }}</h3>
+      </template>
+      <template #body>
+        <p class="b2-regular">Click the card title area or the toggle button to see the title text update.</p>
+      </template>
+    </AvCard>
+  `,
+})
+
+export const CollapsibleWithDynamicTitle = TemplateDynamicTitle.bind({})
+CollapsibleWithDynamicTitle.args = {
+  collapsible: true,
+  collapsed: false,
+}

--- a/src/components/cards/AvCard/AvCard.stub.ts
+++ b/src/components/cards/AvCard/AvCard.stub.ts
@@ -11,7 +11,7 @@ export const AvCardStub = defineComponent({
   },
   template: `
     <div class="av-card">
-      <slot name="title" />
+      <slot name="title" :collapsed="collapsed" />
       <slot />
       <slot name="body" />
       <slot name="footer" />

--- a/src/components/cards/AvCard/AvCard.test.ts
+++ b/src/components/cards/AvCard/AvCard.test.ts
@@ -1,5 +1,6 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { beforeEach, expect } from 'vitest'
+import { h } from 'vue'
 import AvCard from '@/components/cards/AvCard/AvCard.vue'
 import { AvButtonStub } from '@/tests'
 import { BddTest, mountWithRouter } from '@/tests/utils'
@@ -42,6 +43,30 @@ BddTest().given('an AvCard', () => {
         const title = wrapper.get('.av-card__title')
         expect(title.text()).toContain('Titre')
         expect(title.attributes('style')).toContain('background: red')
+      })
+    })
+
+    BddTest().and('with a title scoped slot using collapsed state', () => {
+      BddTest().then('it should pass collapsed state to title slot and update after toggle', async () => {
+        wrapper = await mountWithRouter<typeof AvCard>(AvCard, {
+          props: {
+            collapsible: true,
+            collapsed: false,
+          },
+          slots: {
+            title: ({ collapsed }) => h('h2', collapsed ? 'Collapsed' : 'Expanded'),
+            default: '<p>Contenu principal</p>',
+          },
+          global: {
+            stubs,
+          },
+        })
+
+        expect(wrapper.text()).toContain('Expanded')
+
+        await wrapper.find('.av-card__title').trigger('click')
+
+        expect(wrapper.text()).toContain('Collapsed')
       })
     })
 
@@ -146,14 +171,25 @@ BddTest().given('an AvCard', () => {
         expect(toggleButton.props('icon')).toBe(MDI_ICONS.CHEVRON_LEFT)
       })
 
-      BddTest().and('the card is clicked', () => {
+      BddTest().and('the card title is clicked', () => {
         beforeEach(async () => {
-          await wrapper.find('.av-card').trigger('click')
+          await wrapper.find('.av-card__title').trigger('click')
         })
 
         BddTest().then('it should render the collapsed icon', () => {
           const toggleButton = wrapper.findComponent(AvButtonStub)
           expect(toggleButton.props('icon')).toBe(MDI_ICONS.CHEVRON_DOWN)
+        })
+      })
+
+      BddTest().and('the card body container is clicked', () => {
+        beforeEach(async () => {
+          await wrapper.find('.av-card').trigger('click')
+        })
+
+        BddTest().then('it should still render the non collapsed icon', () => {
+          const toggleButton = wrapper.findComponent(AvButtonStub)
+          expect(toggleButton.props('icon')).toBe(MDI_ICONS.CHEVRON_LEFT)
         })
       })
 
@@ -245,9 +281,9 @@ BddTest().given('an AvCard', () => {
         })
       })
 
-      BddTest().and('the cursor is moved into the card', () => {
+      BddTest().and('the cursor is moved into the card title', () => {
         beforeEach(async () => {
-          await wrapper.find('.av-card').trigger('mousemove')
+          await wrapper.find('.av-card__title').trigger('mousemove')
         })
 
         BddTest().then('it should not render hovering-interactive class', () => {

--- a/src/components/cards/AvCard/AvCard.vue
+++ b/src/components/cards/AvCard/AvCard.vue
@@ -71,8 +71,12 @@ const {
 const slots = defineSlots<{
   /**
    * Slot for the card title.
+   * Receives a `collapsed` boolean prop indicating whether the card is currently collapsed.
+   * This prop can be used to adjust the title content based on the collapsed state.
+   * For example, you might want to show an icon or change the text when the card is collapsed.
+   * Note: The title slot is required if the `collapsible` prop is true, as the collapse button is integrated into the title area.
    */
-  title?: Slot
+  title?: Slot<{ collapsed: boolean }>
 
   /**
    * Slot for the card body.
@@ -153,7 +157,7 @@ function findInteractiveAncestor (target: HTMLElement, currentTarget: EventTarge
   return null
 }
 
-function handleCardClick (event: MouseEvent) {
+function handleHeaderClick (event: MouseEvent) {
   const target = event.target as HTMLElement
   const interactiveElement = findInteractiveAncestor(target, event.currentTarget)
 
@@ -191,16 +195,19 @@ function handleMouseMove (event: MouseEvent) {
     data-testid="av-card"
     :data-collapsible="collapsible"
     :data-collapsed="collapsed"
-    @click="handleCardClick"
-    @mousemove="handleMouseMove"
   >
     <header
       v-if="slots.title"
       class="av-card__title av-row av-align-center av-justify-between av-p-sm av-gap-sm"
       :class="titleClasses"
       :style="{ background: titleBackground, minHeight: titleHeight, maxHeight: titleHeight }"
+      @click="handleHeaderClick"
+      @mousemove="handleMouseMove"
     >
-      <slot name="title" />
+      <slot
+        name="title"
+        :collapsed="collapsed"
+      />
       <AvButton
         v-if="collapsible"
         ref="buttonRef"
@@ -247,19 +254,17 @@ function handleMouseMove (event: MouseEvent) {
     box-sizing: border-box;
   }
 
-  &--collapsible:hover {
-    &:not(.av-card--hovering-interactive) {
-      cursor: pointer;
-      outline: 1px solid v-bind('borderColor');
+  &--collapsible:not(.av-card--hovering-interactive) .av-card__title:hover {
+    cursor: pointer;
+    outline: 1px solid v-bind('borderColor');
 
-      .av-button {
-        background-color: var(--dark-background-primary2);
-        color: var(--other-background-base);
-      }
+    .av-button {
+      background-color: var(--dark-background-primary2);
+      color: var(--other-background-base);
     }
   }
 
-  &--hovering-interactive {
+  &--hovering-interactive .av-card__title:hover {
     cursor: default;
   }
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR updates `AvCard` collapsible behavior and related assets.

**Main changes:**
- ✨ Exposes `collapsed` state to the `title` slot via scoped slot props
- ♻️ Restricts collapse interaction to the card `header` only (instead of the whole card)
- ✅ Updates unit tests to cover header-only collapse and scoped slot state propagation
- 📝 Updates component documentation for the `title` scoped slot API
- 📝 Adds a Storybook story showing a dynamic title based on collapsed state
- 🎨 Updates `AvCard` stub to pass `collapsed` to the `title` slot

---

### Reference to an Issue, Feature, Task, User Story or another PR

Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1734

---

### Documentation
- Updated [AvCard.md](src/components/cards/AvCard/AvCard.md) with `title` scoped slot details
- Added dynamic title story in [AvCard.stories.ts](src/components/cards/AvCard/AvCard.stories.ts)
- Updated tests in [AvCard.test.ts](src/components/cards/AvCard/AvCard.test.ts)

---

### Target Branch
`develop`

---

### Additional Notes
Validation performed:
- `npm run test -- src/components/cards/AvCard/AvCard.test.ts` ✅

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
